### PR TITLE
Resolve config from NOTESPUB_PATH directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 node_modules/
 .claude/
 dist/
-notespub
+/notespub

--- a/cmd/notespub/main.go
+++ b/cmd/notespub/main.go
@@ -66,9 +66,9 @@ func resolveConfigPath(flagValue, notespubPath string) string {
 		return flagValue
 	}
 	if notespubPath != "" {
-		return filepath.Join(expandHome(os.ExpandEnv(notespubPath)), "notespub.yml")
+		return filepath.Join(expandHome(os.ExpandEnv(notespubPath)), config.DefaultConfigFile)
 	}
-	return "notespub.yml"
+	return config.DefaultConfigFile
 }
 
 func loadConfig(cmd *cobra.Command, cfgPath string) (config.Config, error) {

--- a/cmd/notespub/main.go
+++ b/cmd/notespub/main.go
@@ -61,7 +61,9 @@ var serveCmd = &cobra.Command{
 
 func loadConfig(cmd *cobra.Command, cfgPath string) (config.Config, error) {
 	if cfgPath == "" {
-		cfgPath = os.Getenv("NOTESPUB_CONFIG")
+		if dir := os.Getenv("NOTESPUB_PATH"); dir != "" {
+			cfgPath = dir + "/notespub.yml"
+		}
 	}
 	if cfgPath == "" {
 		cfgPath = "notespub.yml"

--- a/cmd/notespub/main.go
+++ b/cmd/notespub/main.go
@@ -5,6 +5,8 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
+	"strings"
 
 	notespub "github.com/dreikanter/notespub"
 	"github.com/dreikanter/notespub/internal/build"
@@ -59,15 +61,18 @@ var serveCmd = &cobra.Command{
 	},
 }
 
+func resolveConfigPath(flagValue, notespubPath string) string {
+	if flagValue != "" {
+		return flagValue
+	}
+	if notespubPath != "" {
+		return filepath.Join(expandHome(os.ExpandEnv(notespubPath)), "notespub.yml")
+	}
+	return "notespub.yml"
+}
+
 func loadConfig(cmd *cobra.Command, cfgPath string) (config.Config, error) {
-	if cfgPath == "" {
-		if dir := os.Getenv("NOTESPUB_PATH"); dir != "" {
-			cfgPath = dir + "/notespub.yml"
-		}
-	}
-	if cfgPath == "" {
-		cfgPath = "notespub.yml"
-	}
+	cfgPath = resolveConfigPath(cfgPath, os.Getenv("NOTESPUB_PATH"))
 
 	envKeys := []string{
 		"NOTES_PATH", "NOTESPUB_ASSETS_PATH", "NOTESPUB_BUILD_PATH",
@@ -90,6 +95,15 @@ func loadConfig(cmd *cobra.Command, cfgPath string) (config.Config, error) {
 	}
 
 	return config.Load(cfgPath, envOverrides, flagOverrides)
+}
+
+func expandHome(path string) string {
+	if strings.HasPrefix(path, "~/") {
+		if home, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(home, path[2:])
+		}
+	}
+	return path
 }
 
 func init() {

--- a/cmd/notespub/main_test.go
+++ b/cmd/notespub/main_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/dreikanter/notespub/internal/config"
 )
 
 func TestResolveConfigPath(t *testing.T) {
@@ -40,7 +42,7 @@ func TestResolveConfigPath(t *testing.T) {
 		{
 			name:         "NOTESPUB_PATH with tilde",
 			notespubPath: "~/notes",
-			want:         filepath.Join(home, "notes", "notespub.yml"),
+			want:         filepath.Join(home, "notes", config.DefaultConfigFile),
 		},
 		{
 			name:         "NOTESPUB_PATH with env var",
@@ -56,7 +58,7 @@ func TestResolveConfigPath(t *testing.T) {
 		},
 		{
 			name: "falls back to cwd",
-			want: "notespub.yml",
+			want: config.DefaultConfigFile,
 		},
 	}
 

--- a/cmd/notespub/main_test.go
+++ b/cmd/notespub/main_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveConfigPath(t *testing.T) {
+	home, _ := os.UserHomeDir()
+
+	tests := []struct {
+		name         string
+		flagValue    string
+		notespubPath string
+		env          map[string]string
+		want         string
+	}{
+		{
+			name:      "flag takes precedence",
+			flagValue: "/explicit/config.yml",
+			want:      "/explicit/config.yml",
+		},
+		{
+			name:         "flag takes precedence over NOTESPUB_PATH",
+			flagValue:    "/explicit/config.yml",
+			notespubPath: "/some/dir",
+			want:         "/explicit/config.yml",
+		},
+		{
+			name:         "NOTESPUB_PATH basic",
+			notespubPath: "/some/dir",
+			want:         "/some/dir/notespub.yml",
+		},
+		{
+			name:         "NOTESPUB_PATH with trailing slash",
+			notespubPath: "/some/dir/",
+			want:         "/some/dir/notespub.yml",
+		},
+		{
+			name:         "NOTESPUB_PATH with tilde",
+			notespubPath: "~/notes",
+			want:         filepath.Join(home, "notes", "notespub.yml"),
+		},
+		{
+			name:         "NOTESPUB_PATH with env var",
+			notespubPath: "$TEST_NOTESPUB_HOME/notes",
+			env:          map[string]string{"TEST_NOTESPUB_HOME": "/expanded"},
+			want:         "/expanded/notes/notespub.yml",
+		},
+		{
+			name:         "NOTESPUB_PATH with env var and trailing slash",
+			notespubPath: "$TEST_NOTESPUB_HOME/notes/",
+			env:          map[string]string{"TEST_NOTESPUB_HOME": "/expanded"},
+			want:         "/expanded/notes/notespub.yml",
+		},
+		{
+			name: "falls back to cwd",
+			want: "notespub.yml",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+			got := resolveConfigPath(tt.flagValue, tt.notespubPath)
+			if got != tt.want {
+				t.Errorf("resolveConfigPath(%q, %q) = %q, want %q",
+					tt.flagValue, tt.notespubPath, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExpandHome(t *testing.T) {
+	home, _ := os.UserHomeDir()
+
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{
+			name: "tilde prefix",
+			path: "~/documents",
+			want: filepath.Join(home, "documents"),
+		},
+		{
+			name: "tilde only slash",
+			path: "~/",
+			want: home,
+		},
+		{
+			name: "no tilde",
+			path: "/absolute/path",
+			want: "/absolute/path",
+		},
+		{
+			name: "tilde in middle is not expanded",
+			path: "/some/~/path",
+			want: "/some/~/path",
+		},
+		{
+			name: "relative path unchanged",
+			path: "relative/path",
+			want: "relative/path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := expandHome(tt.path)
+			if got != tt.want {
+				t.Errorf("expandHome(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,6 +9,9 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// DefaultConfigFile is the conventional config file name.
+const DefaultConfigFile = "notespub.yml"
+
 // Config holds all configuration for a notespub build.
 type Config struct {
 	NotesPath   string `yaml:"notes_path"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestLoadFromYAML(t *testing.T) {
 	dir := t.TempDir()
-	yamlPath := filepath.Join(dir, "notespub.yml")
+	yamlPath := filepath.Join(dir, DefaultConfigFile)
 	err := os.WriteFile(yamlPath, []byte(`
 notes_path: "/tmp/notes"
 assets_path: "/tmp/assets"
@@ -48,7 +48,7 @@ author_name: "Test Author"
 
 func TestEnvOverridesYAML(t *testing.T) {
 	dir := t.TempDir()
-	yamlPath := filepath.Join(dir, "notespub.yml")
+	yamlPath := filepath.Join(dir, DefaultConfigFile)
 	err := os.WriteFile(yamlPath, []byte(`
 notes_path: "/tmp/notes"
 assets_path: "/tmp/assets"
@@ -88,7 +88,7 @@ author_name: "Test Author"
 
 func TestFlagOverridesEnv(t *testing.T) {
 	dir := t.TempDir()
-	yamlPath := filepath.Join(dir, "notespub.yml")
+	yamlPath := filepath.Join(dir, DefaultConfigFile)
 	err := os.WriteFile(yamlPath, []byte(`
 notes_path: "/tmp/notes"
 assets_path: "/tmp/assets"
@@ -121,7 +121,7 @@ author_name: "Test Author"
 
 func TestLoadMissingRequiredField(t *testing.T) {
 	dir := t.TempDir()
-	yamlPath := filepath.Join(dir, "notespub.yml")
+	yamlPath := filepath.Join(dir, DefaultConfigFile)
 	err := os.WriteFile(yamlPath, []byte(`
 notes_path: "/tmp/notes"
 `), 0o644)
@@ -137,7 +137,7 @@ notes_path: "/tmp/notes"
 
 func TestExpandHomePath(t *testing.T) {
 	dir := t.TempDir()
-	yamlPath := filepath.Join(dir, "notespub.yml")
+	yamlPath := filepath.Join(dir, DefaultConfigFile)
 	err := os.WriteFile(yamlPath, []byte(`
 notes_path: "~/notes"
 assets_path: "~/assets"


### PR DESCRIPTION
## Summary
- Config file resolution: `--config` flag → `$NOTESPUB_PATH/notespub.yml` → `./notespub.yml`
- Replaces `NOTESPUB_CONFIG` (full file path) with `NOTESPUB_PATH` (directory)
- Fix `.gitignore` pattern to not ignore `cmd/notespub/` directory

Closes #1