### PR TITLE
Drop per-field environment variable overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,20 +29,20 @@ site_name: "My Notes"
 author_name: "Your Name"
 ```
 
-All values can be overridden with environment variables or CLI flags:
+All values can be overridden with CLI flags:
 
-| YAML key | Env var | CLI flag |
-|---|---|---|
-| `notes_path` | `NOTES_PATH` | `--notes-path` |
-| `assets_path` | `NOTESPUB_ASSETS_PATH` | `--assets-path` |
-| `build_path` | `NOTESPUB_BUILD_PATH` | `--out` |
-| `site_root_url` | `NOTESPUB_SITE_ROOT_URL` | `--url` |
-| `site_name` | `NOTESPUB_SITE_NAME` | `--site-name` |
-| `author_name` | `NOTESPUB_AUTHOR_NAME` | `--author` |
+| YAML key | CLI flag |
+|---|---|
+| `notes_path` | `--notes-path` |
+| `assets_path` | `--assets-path` |
+| `build_path` | `--out` |
+| `site_root_url` | `--url` |
+| `site_name` | `--site-name` |
+| `author_name` | `--author` |
 
-Priority: CLI flags > environment variables > YAML file.
+Priority: CLI flags > YAML file.
 
-The config file path defaults to `notespub.yml` in the current directory. Override it with `--config` or the `NOTESPUB_CONFIG` env var.
+The config file path defaults to `notespub.yml` in the current directory. Override it with `--config` or set `NOTESPUB_PATH` to the directory containing the config file.
 
 ## Usage
 

--- a/cmd/notespub/main.go
+++ b/cmd/notespub/main.go
@@ -74,17 +74,6 @@ func resolveConfigPath(flagValue, notespubPath string) string {
 func loadConfig(cmd *cobra.Command, cfgPath string) (config.Config, error) {
 	cfgPath = resolveConfigPath(cfgPath, os.Getenv("NOTESPUB_PATH"))
 
-	envKeys := []string{
-		"NOTES_PATH", "NOTESPUB_ASSETS_PATH", "NOTESPUB_BUILD_PATH",
-		"NOTESPUB_SITE_ROOT_URL", "NOTESPUB_SITE_NAME", "NOTESPUB_AUTHOR_NAME",
-	}
-	envOverrides := make(map[string]string)
-	for _, key := range envKeys {
-		if v := os.Getenv(key); v != "" {
-			envOverrides[key] = v
-		}
-	}
-
 	flagNames := []string{"notes-path", "assets-path", "out", "url", "site-name", "author"}
 	flagOverrides := make(map[string]string)
 	for _, name := range flagNames {
@@ -94,7 +83,7 @@ func loadConfig(cmd *cobra.Command, cfgPath string) (config.Config, error) {
 		}
 	}
 
-	return config.Load(cfgPath, envOverrides, flagOverrides)
+	return config.Load(cfgPath, flagOverrides)
 }
 
 func expandHome(path string) string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,9 +55,8 @@ func (c Config) FeedPath() string {
 	return root + "/feed.xml"
 }
 
-// Load reads configuration from a YAML file, then overlays environment variables,
-// then overlays flag values.
-func Load(yamlPath string, envOverrides map[string]string, flagOverrides map[string]string) (Config, error) {
+// Load reads configuration from a YAML file, then overlays flag values.
+func Load(yamlPath string, flagOverrides map[string]string) (Config, error) {
 	data, err := os.ReadFile(yamlPath)
 	if err != nil {
 		return Config{}, fmt.Errorf("cannot read config: %w", err)
@@ -66,20 +65,6 @@ func Load(yamlPath string, envOverrides map[string]string, flagOverrides map[str
 	var cfg Config
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
 		return Config{}, fmt.Errorf("cannot parse config: %w", err)
-	}
-
-	envMap := map[string]*string{
-		"NOTES_PATH":             &cfg.NotesPath,
-		"NOTESPUB_ASSETS_PATH":   &cfg.AssetsPath,
-		"NOTESPUB_BUILD_PATH":    &cfg.BuildPath,
-		"NOTESPUB_SITE_ROOT_URL": &cfg.SiteRootURL,
-		"NOTESPUB_SITE_NAME":     &cfg.SiteName,
-		"NOTESPUB_AUTHOR_NAME":   &cfg.AuthorName,
-	}
-	for envKey, ptr := range envMap {
-		if v, ok := envOverrides[envKey]; ok && v != "" {
-			*ptr = v
-		}
 	}
 
 	flagMap := map[string]*string{

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -21,7 +21,7 @@ author_name: "Test Author"
 		t.Fatal(err)
 	}
 
-	cfg, err := Load(yamlPath, nil, nil)
+	cfg, err := Load(yamlPath, nil)
 	if err != nil {
 		t.Fatalf("Load() error: %v", err)
 	}
@@ -46,7 +46,7 @@ author_name: "Test Author"
 	}
 }
 
-func TestEnvOverridesYAML(t *testing.T) {
+func TestFlagOverridesYAML(t *testing.T) {
 	dir := t.TempDir()
 	yamlPath := filepath.Join(dir, DefaultConfigFile)
 	err := os.WriteFile(yamlPath, []byte(`
@@ -59,57 +59,13 @@ author_name: "Test Author"
 `), 0o644)
 	if err != nil {
 		t.Fatal(err)
-	}
-
-	envOverrides := map[string]string{
-		"NOTES_PATH":             "/env/notes",
-		"NOTESPUB_BUILD_PATH":    "/env/dist",
-		"NOTESPUB_SITE_ROOT_URL": "https://env.example.com",
-		"NOTESPUB_SITE_NAME":     "Env Site",
-		"NOTESPUB_AUTHOR_NAME":   "Env Author",
-		"NOTESPUB_ASSETS_PATH":   "/env/assets",
-	}
-
-	cfg, err := Load(yamlPath, envOverrides, nil)
-	if err != nil {
-		t.Fatalf("Load() error: %v", err)
-	}
-
-	if cfg.NotesPath != "/env/notes" {
-		t.Errorf("NotesPath = %q, want /env/notes", cfg.NotesPath)
-	}
-	if cfg.BuildPath != "/env/dist" {
-		t.Errorf("BuildPath = %q, want /env/dist", cfg.BuildPath)
-	}
-	if cfg.SiteRootURL != "https://env.example.com" {
-		t.Errorf("SiteRootURL = %q, want https://env.example.com", cfg.SiteRootURL)
-	}
-}
-
-func TestFlagOverridesEnv(t *testing.T) {
-	dir := t.TempDir()
-	yamlPath := filepath.Join(dir, DefaultConfigFile)
-	err := os.WriteFile(yamlPath, []byte(`
-notes_path: "/tmp/notes"
-assets_path: "/tmp/assets"
-build_path: "./dist"
-site_root_url: "https://example.com"
-site_name: "Test Site"
-author_name: "Test Author"
-`), 0o644)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	envOverrides := map[string]string{
-		"NOTES_PATH": "/env/notes",
 	}
 
 	flagOverrides := map[string]string{
 		"notes-path": "/flag/notes",
 	}
 
-	cfg, err := Load(yamlPath, envOverrides, flagOverrides)
+	cfg, err := Load(yamlPath, flagOverrides)
 	if err != nil {
 		t.Fatalf("Load() error: %v", err)
 	}
@@ -129,7 +85,7 @@ notes_path: "/tmp/notes"
 		t.Fatal(err)
 	}
 
-	_, err = Load(yamlPath, nil, nil)
+	_, err = Load(yamlPath, nil)
 	if err == nil {
 		t.Fatal("Load() expected error for missing required fields, got nil")
 	}
@@ -150,7 +106,7 @@ author_name: "Test Author"
 		t.Fatal(err)
 	}
 
-	cfg, err := Load(yamlPath, nil, nil)
+	cfg, err := Load(yamlPath, nil)
 	if err != nil {
 		t.Fatalf("Load() error: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Remove per-field env var config overrides (NOTES_PATH, NOTESPUB_BUILD_PATH, etc.)
- Keep NOTESPUB_PATH for config file resolution
- Simplify config priority to CLI flags > YAML file
- Update tests and README to match

## Test plan
- [x] All existing tests pass with updated signatures
- [x] `notespub build` still reads from YAML and respects CLI flags
- [x] `NOTESPUB_PATH` still resolves config file location