### PR TITLE
Rename NOTESPUB_PATH to NOTESPUB_CONFIG

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ All values can be overridden with CLI flags:
 
 Priority: CLI flags > YAML file.
 
-The config file path defaults to `notespub.yml` in the current directory. Override it with `--config` or set `NOTESPUB_PATH` to the directory containing the config file.
+The config file path defaults to `notespub.yml` in the current directory. Override it with `--config` or `NOTESPUB_CONFIG` env var.
 
 ## Usage
 

--- a/cmd/notespub/main.go
+++ b/cmd/notespub/main.go
@@ -61,18 +61,18 @@ var serveCmd = &cobra.Command{
 	},
 }
 
-func resolveConfigPath(flagValue, notespubPath string) string {
+func resolveConfigPath(flagValue, envValue string) string {
 	if flagValue != "" {
-		return flagValue
+		return expandHome(os.ExpandEnv(flagValue))
 	}
-	if notespubPath != "" {
-		return filepath.Join(expandHome(os.ExpandEnv(notespubPath)), config.DefaultConfigFile)
+	if envValue != "" {
+		return expandHome(os.ExpandEnv(envValue))
 	}
 	return config.DefaultConfigFile
 }
 
 func loadConfig(cmd *cobra.Command, cfgPath string) (config.Config, error) {
-	cfgPath = resolveConfigPath(cfgPath, os.Getenv("NOTESPUB_PATH"))
+	cfgPath = resolveConfigPath(cfgPath, os.Getenv("NOTESPUB_CONFIG"))
 
 	flagNames := []string{"notes-path", "assets-path", "out", "url", "site-name", "author"}
 	flagOverrides := make(map[string]string)

--- a/cmd/notespub/main_test.go
+++ b/cmd/notespub/main_test.go
@@ -12,11 +12,11 @@ func TestResolveConfigPath(t *testing.T) {
 	home, _ := os.UserHomeDir()
 
 	tests := []struct {
-		name         string
-		flagValue    string
-		notespubPath string
-		env          map[string]string
-		want         string
+		name      string
+		flagValue string
+		envValue  string
+		env       map[string]string
+		want      string
 	}{
 		{
 			name:      "flag takes precedence",
@@ -24,37 +24,26 @@ func TestResolveConfigPath(t *testing.T) {
 			want:      "/explicit/config.yml",
 		},
 		{
-			name:         "flag takes precedence over NOTESPUB_PATH",
-			flagValue:    "/explicit/config.yml",
-			notespubPath: "/some/dir",
-			want:         "/explicit/config.yml",
+			name:      "flag takes precedence over NOTESPUB_CONFIG",
+			flagValue: "/explicit/config.yml",
+			envValue:  "/some/dir/notespub.yml",
+			want:      "/explicit/config.yml",
 		},
 		{
-			name:         "NOTESPUB_PATH basic",
-			notespubPath: "/some/dir",
-			want:         "/some/dir/notespub.yml",
+			name:     "NOTESPUB_CONFIG basic",
+			envValue: "/some/dir/notespub.yml",
+			want:     "/some/dir/notespub.yml",
 		},
 		{
-			name:         "NOTESPUB_PATH with trailing slash",
-			notespubPath: "/some/dir/",
-			want:         "/some/dir/notespub.yml",
+			name:     "NOTESPUB_CONFIG with tilde",
+			envValue: "~/notes/notespub.yml",
+			want:     filepath.Join(home, "notes", "notespub.yml"),
 		},
 		{
-			name:         "NOTESPUB_PATH with tilde",
-			notespubPath: "~/notes",
-			want:         filepath.Join(home, "notes", config.DefaultConfigFile),
-		},
-		{
-			name:         "NOTESPUB_PATH with env var",
-			notespubPath: "$TEST_NOTESPUB_HOME/notes",
-			env:          map[string]string{"TEST_NOTESPUB_HOME": "/expanded"},
-			want:         "/expanded/notes/notespub.yml",
-		},
-		{
-			name:         "NOTESPUB_PATH with env var and trailing slash",
-			notespubPath: "$TEST_NOTESPUB_HOME/notes/",
-			env:          map[string]string{"TEST_NOTESPUB_HOME": "/expanded"},
-			want:         "/expanded/notes/notespub.yml",
+			name:     "NOTESPUB_CONFIG with env var",
+			envValue: "$TEST_NOTESPUB_HOME/notespub.yml",
+			env:      map[string]string{"TEST_NOTESPUB_HOME": "/expanded"},
+			want:     "/expanded/notespub.yml",
 		},
 		{
 			name: "falls back to cwd",
@@ -67,10 +56,10 @@ func TestResolveConfigPath(t *testing.T) {
 			for k, v := range tt.env {
 				t.Setenv(k, v)
 			}
-			got := resolveConfigPath(tt.flagValue, tt.notespubPath)
+			got := resolveConfigPath(tt.flagValue, tt.envValue)
 			if got != tt.want {
 				t.Errorf("resolveConfigPath(%q, %q) = %q, want %q",
-					tt.flagValue, tt.notespubPath, got, tt.want)
+					tt.flagValue, tt.envValue, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Rename `NOTESPUB_PATH` env var to `NOTESPUB_CONFIG`, pointing directly to the config file instead of a directory
- Expand tilde and env vars in `--config` flag values
- Update tests and README

## Test plan
- [x] All tests pass
- [x] `NOTESPUB_CONFIG=~/path/to/notespub.yml notespub build` works
- [x] `notespub build --config ~/path/to/notespub.yml` works
- [x] Falls back to `notespub.yml` in cwd when neither is set