### PR TITLE
Clean build directory before building

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Create a `notespub.yml` file:
 notes_path: "~/Notes"
 build_path: "./dist"
 assets_path: "~/NotesImages"
+static_path: "~/NotesStatic"
 site_root_url: "https://example.com"
 site_name: "My Notes"
 author_name: "Your Name"
@@ -36,6 +37,7 @@ All values can be overridden with CLI flags:
 | `notes_path` | `--notes-path` |
 | `assets_path` | `--assets-path` |
 | `build_path` | `--out` |
+| `static_path` | `--static` |
 | `site_root_url` | `--url` |
 | `site_name` | `--site-name` |
 | `author_name` | `--author` |

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Create a `notespub.yml` file:
 notes_path: "~/Notes"
 build_path: "./dist"
 assets_path: "~/NotesImages"
-static_path: "~/NotesStatic"
 site_root_url: "https://example.com"
 site_name: "My Notes"
 author_name: "Your Name"
@@ -45,6 +44,10 @@ All values can be overridden with CLI flags:
 Priority: CLI flags > YAML file.
 
 The config file path defaults to `notespub.yml` in the current directory. Override it with `--config` or `NOTESPUB_CONFIG` env var.
+
+## Static files
+
+Files in the `static` subdirectory of `notes_path` are copied as-is to the build output root. Use this for files like `CNAME`, `robots.txt`, or `favicon.ico`. Override the location with `static_path` in the config or `--static` flag.
 
 ## Usage
 

--- a/cmd/notespub/main.go
+++ b/cmd/notespub/main.go
@@ -74,7 +74,7 @@ func resolveConfigPath(flagValue, envValue string) string {
 func loadConfig(cmd *cobra.Command, cfgPath string) (config.Config, error) {
 	cfgPath = resolveConfigPath(cfgPath, os.Getenv("NOTESPUB_CONFIG"))
 
-	flagNames := []string{"notes-path", "assets-path", "out", "url", "site-name", "author"}
+	flagNames := []string{"notes-path", "assets-path", "out", "static", "url", "site-name", "author"}
 	flagOverrides := make(map[string]string)
 	for _, name := range flagNames {
 		if cmd.Flags().Changed(name) {
@@ -100,6 +100,7 @@ func init() {
 	buildCmd.Flags().String("notes-path", "", "notes store path")
 	buildCmd.Flags().String("assets-path", "", "image assets path")
 	buildCmd.Flags().String("out", "", "output directory (default: ./dist)")
+	buildCmd.Flags().String("static", "", "static files directory")
 	buildCmd.Flags().String("url", "", "site root URL")
 	buildCmd.Flags().String("site-name", "", "site name")
 	buildCmd.Flags().String("author", "", "author name")

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -3,6 +3,7 @@ package build
 import (
 	"fmt"
 	"html/template"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -124,11 +125,51 @@ func cleanBuildDir(buildPath string) error {
 	return nil
 }
 
+// copyStaticFiles copies all files from staticPath to buildPath, preserving
+// directory structure.
+func copyStaticFiles(staticPath, buildPath string) error {
+	return filepath.WalkDir(staticPath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(staticPath, path)
+		if err != nil {
+			return err
+		}
+		dest := filepath.Join(buildPath, rel)
+		if d.IsDir() {
+			return os.MkdirAll(dest, 0o755)
+		}
+		src, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer src.Close()
+		if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+			return err
+		}
+		dst, err := os.Create(dest)
+		if err != nil {
+			return err
+		}
+		defer dst.Close()
+		_, err = io.Copy(dst, src)
+		return err
+	})
+}
+
 // Build generates the static site from notes.
 func Build(cfg config.Config, templateFS fs.FS, styleCSS []byte) error {
 	// 0. Clean build directory.
 	if err := cleanBuildDir(cfg.BuildPath); err != nil {
 		return err
+	}
+
+	// 0b. Copy static files.
+	if cfg.StaticPath != "" {
+		if err := copyStaticFiles(cfg.StaticPath, cfg.BuildPath); err != nil {
+			return fmt.Errorf("copying static files: %w", err)
+		}
 	}
 
 	// 1. Scan notes.

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -92,8 +92,45 @@ type feedNoteData struct {
 	Body  string
 }
 
+// cleanBuildDir removes all non-dotfile entries from the build directory,
+// preserving dotfiles and dotdirs (e.g. .git, .nojekyll).
+func cleanBuildDir(buildPath string) error {
+	abs, err := filepath.Abs(buildPath)
+	if err != nil {
+		return fmt.Errorf("resolving build path: %w", err)
+	}
+
+	home, _ := os.UserHomeDir()
+	if abs == "/" || abs == home {
+		return fmt.Errorf("refusing to clean dangerous build path: %s", abs)
+	}
+
+	entries, err := os.ReadDir(abs)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("reading build dir: %w", err)
+	}
+
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".") {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(abs, e.Name())); err != nil {
+			return fmt.Errorf("removing %s: %w", e.Name(), err)
+		}
+	}
+	return nil
+}
+
 // Build generates the static site from notes.
 func Build(cfg config.Config, templateFS fs.FS, styleCSS []byte) error {
+	// 0. Clean build directory.
+	if err := cleanBuildDir(cfg.BuildPath); err != nil {
+		return err
+	}
+
 	// 1. Scan notes.
 	notes, err := note.Scan(cfg.NotesPath)
 	if err != nil {

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -126,8 +126,11 @@ func cleanBuildDir(buildPath string) error {
 }
 
 // copyStaticFiles copies all files from staticPath to buildPath, preserving
-// directory structure.
+// directory structure. Returns nil if staticPath does not exist.
 func copyStaticFiles(staticPath, buildPath string) error {
+	if _, err := os.Stat(staticPath); os.IsNotExist(err) {
+		return nil
+	}
 	return filepath.WalkDir(staticPath, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -54,6 +54,38 @@ func TestCleanBuildDirRejectsRoot(t *testing.T) {
 	}
 }
 
+func TestCopyStaticFiles(t *testing.T) {
+	staticDir := t.TempDir()
+	buildDir := t.TempDir()
+
+	// Create static files.
+	os.WriteFile(filepath.Join(staticDir, "CNAME"), []byte("example.com"), 0o644)
+	os.WriteFile(filepath.Join(staticDir, "README.md"), []byte("# Hello"), 0o644)
+	os.MkdirAll(filepath.Join(staticDir, "sub"), 0o755)
+	os.WriteFile(filepath.Join(staticDir, "sub", "file.txt"), []byte("nested"), 0o644)
+
+	if err := copyStaticFiles(staticDir, buildDir); err != nil {
+		t.Fatalf("copyStaticFiles() error: %v", err)
+	}
+
+	// Verify files were copied.
+	data, err := os.ReadFile(filepath.Join(buildDir, "CNAME"))
+	if err != nil {
+		t.Fatal("CNAME not copied")
+	}
+	if string(data) != "example.com" {
+		t.Errorf("CNAME = %q, want example.com", data)
+	}
+
+	data, err = os.ReadFile(filepath.Join(buildDir, "sub", "file.txt"))
+	if err != nil {
+		t.Fatal("sub/file.txt not copied")
+	}
+	if string(data) != "nested" {
+		t.Errorf("sub/file.txt = %q, want nested", data)
+	}
+}
+
 func TestCleanBuildDirRejectsHome(t *testing.T) {
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -9,6 +9,61 @@ import (
 	"github.com/dreikanter/notespub/internal/config"
 )
 
+func TestCleanBuildDir(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create regular files and dirs.
+	os.WriteFile(filepath.Join(dir, "index.html"), []byte("hi"), 0o644)
+	os.MkdirAll(filepath.Join(dir, "subdir"), 0o755)
+	os.WriteFile(filepath.Join(dir, "subdir", "page.html"), []byte("hi"), 0o644)
+
+	// Create dotfiles and dotdirs that should survive.
+	os.MkdirAll(filepath.Join(dir, ".git", "objects"), 0o755)
+	os.WriteFile(filepath.Join(dir, ".nojekyll"), []byte(""), 0o644)
+
+	if err := cleanBuildDir(dir); err != nil {
+		t.Fatalf("cleanBuildDir() error: %v", err)
+	}
+
+	// Regular files should be gone.
+	if _, err := os.Stat(filepath.Join(dir, "index.html")); !os.IsNotExist(err) {
+		t.Error("index.html should have been removed")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "subdir")); !os.IsNotExist(err) {
+		t.Error("subdir should have been removed")
+	}
+
+	// Dotfiles should remain.
+	if _, err := os.Stat(filepath.Join(dir, ".git", "objects")); err != nil {
+		t.Error(".git/objects should have been preserved")
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".nojekyll")); err != nil {
+		t.Error(".nojekyll should have been preserved")
+	}
+}
+
+func TestCleanBuildDirNonExistent(t *testing.T) {
+	if err := cleanBuildDir("/tmp/notespub-does-not-exist-" + t.Name()); err != nil {
+		t.Fatalf("cleanBuildDir() should not error for non-existent dir, got: %v", err)
+	}
+}
+
+func TestCleanBuildDirRejectsRoot(t *testing.T) {
+	if err := cleanBuildDir("/"); err == nil {
+		t.Fatal("cleanBuildDir('/') should return an error")
+	}
+}
+
+func TestCleanBuildDirRejectsHome(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("cannot determine home dir")
+	}
+	if err := cleanBuildDir(home); err == nil {
+		t.Fatal("cleanBuildDir(home) should return an error")
+	}
+}
+
 func writeTestNote(t *testing.T, root, relPath, content string) {
 	t.Helper()
 	full := filepath.Join(root, relPath)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	NotesPath   string `yaml:"notes_path"`
 	AssetsPath  string `yaml:"assets_path"`
 	BuildPath   string `yaml:"build_path"`
+	StaticPath  string `yaml:"static_path"`
 	SiteRootURL string `yaml:"site_root_url"`
 	SiteName    string `yaml:"site_name"`
 	AuthorName  string `yaml:"author_name"`
@@ -71,6 +72,7 @@ func Load(yamlPath string, flagOverrides map[string]string) (Config, error) {
 		"notes-path":  &cfg.NotesPath,
 		"assets-path": &cfg.AssetsPath,
 		"out":         &cfg.BuildPath,
+		"static":      &cfg.StaticPath,
 		"url":         &cfg.SiteRootURL,
 		"site-name":   &cfg.SiteName,
 		"author":      &cfg.AuthorName,
@@ -84,6 +86,7 @@ func Load(yamlPath string, flagOverrides map[string]string) (Config, error) {
 	cfg.NotesPath = expandHome(cfg.NotesPath)
 	cfg.AssetsPath = expandHome(cfg.AssetsPath)
 	cfg.BuildPath = expandHome(cfg.BuildPath)
+	cfg.StaticPath = expandHome(cfg.StaticPath)
 
 	if cfg.SiteRootURL == "" {
 		return Config{}, fmt.Errorf("site_root_url is required")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -87,6 +87,9 @@ func Load(yamlPath string, flagOverrides map[string]string) (Config, error) {
 	cfg.AssetsPath = expandHome(cfg.AssetsPath)
 	cfg.BuildPath = expandHome(cfg.BuildPath)
 	cfg.StaticPath = expandHome(cfg.StaticPath)
+	if cfg.StaticPath == "" && cfg.NotesPath != "" {
+		cfg.StaticPath = filepath.Join(cfg.NotesPath, "static")
+	}
 
 	if cfg.SiteRootURL == "" {
 		return Config{}, fmt.Errorf("site_root_url is required")


### PR DESCRIPTION
## Summary
- Remove all non-dotfile entries from build dir before writing output
- Preserves dotfiles/dotdirs (`.git`, `.nojekyll`, etc.) so output can target a Git-based deployment repo directly
- Rejects `/` and `$HOME` as build paths as a safety measure

## Test plan
- [x] All existing tests pass
- [x] New tests: clean removes regular files, preserves dotfiles/dotdirs
- [x] New tests: no error for non-existent dir
- [x] New tests: rejects root and home directory
- [x] Build to a git repo dir, verify `.git` survives and stale files are removed