### PR TITLE
Add build version tracking via ldflags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,22 @@
-.PHONY: build dev test lint
+.PHONY: build dev test lint clean install
+
+BINARY := notespub
+VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+LDFLAGS := -X main.Version=$(VERSION)
 
 build:  ## Compile CSS then build binary
 	npx tailwindcss -i stylesheets/main.css -o style.css --minify
-	go build ./cmd/notespub
+	go build -ldflags "$(LDFLAGS)" -o $(BINARY) ./cmd/notespub
 
 dev:    ## Watch mode: recompile on changes
 	npx tailwindcss -i stylesheets/main.css -o style.css --watch &
-	go build ./cmd/notespub
+	go build -ldflags "$(LDFLAGS)" -o $(BINARY) ./cmd/notespub
+
+clean:
+	rm -f $(BINARY)
+
+install:
+	go install -ldflags "$(LDFLAGS)" ./cmd/notespub
 
 test:
 	go test ./...

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build dev test lint clean install
+.PHONY: build dev test lint clean install update
 
 BINARY := notespub
 VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
@@ -17,6 +17,12 @@ clean:
 
 install:
 	go install -ldflags "$(LDFLAGS)" ./cmd/notespub
+
+update:
+	git checkout main
+	git pull --tags
+	$(MAKE) install
+	@echo "Installed: $$(notespub --version)"
 
 test:
 	go test ./...

--- a/cmd/notespub/main.go
+++ b/cmd/notespub/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strings"
 
 	notespub "github.com/dreikanter/notespub"
@@ -13,6 +14,8 @@ import (
 	"github.com/dreikanter/notespub/internal/config"
 	"github.com/spf13/cobra"
 )
+
+var Version = "dev"
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
@@ -96,6 +99,13 @@ func expandHome(path string) string {
 }
 
 func init() {
+	if Version == "dev" {
+		if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "(devel)" {
+			Version = info.Main.Version
+		}
+	}
+	rootCmd.Version = Version
+
 	buildCmd.Flags().String("config", "", "config file path (default: notespub.yml)")
 	buildCmd.Flags().String("notes-path", "", "notes store path")
 	buildCmd.Flags().String("assets-path", "", "image assets path")


### PR DESCRIPTION
## Summary
- Inject version from `git describe --tags` via ldflags at build time
- Fall back to `runtime/debug.ReadBuildInfo` when built without ldflags
- Add `clean` and `install` Makefile targets

## Test plan
- [x] `go build && ./notespub --version` shows build info fallback
- [x] `go build -ldflags "-X main.Version=test" && ./notespub --version` shows injected version
- [x] `go test ./...` passes