### PR TITLE
Add site domain and CC BY license to footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,19 +32,17 @@ author_name: "Ada Lovelace"
 
 All values can be overridden with CLI flags:
 
-| YAML key | CLI flag |
-|---|---|
-| `notes_path` | `--notes` |
-| `assets_path` | `--assets` |
-| `build_path` | `--out` |
-| `static_path` | `--static` |
-| `site_root_url` | `--url` |
-| `site_name` | `--site-name` |
-| `author_name` | `--author` |
-| `license_name` | `--license-name` |
-| `license_url` | `--license-url` |
-
-`license_name` and `license_url` default to "CC BY 4.0" and `https://creativecommons.org/licenses/by/4.0/`.
+| YAML key | CLI flag | Default |
+|---|---|---|
+| `notes_path` | `--notes` | |
+| `assets_path` | `--assets` | `<notes_path>/images` |
+| `build_path` | `--out` | |
+| `static_path` | `--static` | `<notes_path>/static` |
+| `site_root_url` | `--url` | |
+| `site_name` | `--site-name` | |
+| `author_name` | `--author` | |
+| `license_name` | `--license-name` | CC BY 4.0 |
+| `license_url` | `--license-url` | https://creativecommons.org/licenses/by/4.0/ |
 
 Priority: CLI flags > YAML config.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ author_name: "Ada Lovelace"
 
 All values can be overridden with CLI flags:
 
-| YAML key | CLI flag | Default |
+| Config option | CLI flag | Default |
 |---|---|---|
 | `notes_path` | `--notes` | |
 | `assets_path` | `--assets` | `<notes_path>/images` |

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ All values can be overridden with CLI flags:
 | `site_root_url` | `--url` |
 | `site_name` | `--site-name` |
 | `author_name` | `--author` |
+| `license_name` | `--license-name` |
+| `license_url` | `--license-url` |
+
+`license_name` and `license_url` default to "CC BY 4.0" and `https://creativecommons.org/licenses/by/4.0/`.
 
 Priority: CLI flags > YAML config.
 

--- a/cmd/notespub/main.go
+++ b/cmd/notespub/main.go
@@ -77,7 +77,7 @@ func resolveConfigPath(flagValue, envValue string) string {
 func loadConfig(cmd *cobra.Command, cfgPath string) (config.Config, error) {
 	cfgPath = resolveConfigPath(cfgPath, os.Getenv("NOTESPUB_CONFIG"))
 
-	flagNames := []string{"notes", "assets", "out", "static", "url", "site-name", "author"}
+	flagNames := []string{"notes", "assets", "out", "static", "url", "site-name", "author", "license-name", "license-url"}
 	flagOverrides := make(map[string]string)
 	for _, name := range flagNames {
 		if cmd.Flags().Changed(name) {
@@ -114,6 +114,8 @@ func init() {
 	buildCmd.Flags().String("url", "", "site root URL")
 	buildCmd.Flags().String("site-name", "", "site name")
 	buildCmd.Flags().String("author", "", "author name")
+	buildCmd.Flags().String("license-name", "", "license name (default: CC BY 4.0)")
+	buildCmd.Flags().String("license-url", "", "license URL (default: https://creativecommons.org/licenses/by/4.0/)")
 
 	serveCmd.Flags().String("dir", "./dist", "directory to serve")
 	serveCmd.Flags().String("port", "4000", "port to listen on")

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -37,6 +37,8 @@ type configData struct {
 	AuthorName   string
 	FeedURL      string
 	FeedPath     string
+	LicenseName  string
+	LicenseURL   string
 	HighlightCSS template.CSS
 }
 
@@ -276,6 +278,8 @@ func Build(cfg config.Config, templateFS fs.FS, styleCSS []byte) error {
 		AuthorName:   cfg.AuthorName,
 		FeedURL:      cfg.FeedURL(),
 		FeedPath:     cfg.FeedPath(),
+		LicenseName:  cfg.LicenseName,
+		LicenseURL:   cfg.LicenseURL,
 		HighlightCSS: template.CSS(render.HighlightCSS()),
 	}
 

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -31,6 +31,7 @@ type layoutData struct {
 // configData is the subset of config passed to templates.
 type configData struct {
 	SiteName     string
+	SiteDomain   string
 	SiteRootURL  string
 	SiteRootPath string
 	AuthorName   string
@@ -269,6 +270,7 @@ func Build(cfg config.Config, templateFS fs.FS, styleCSS []byte) error {
 
 	cfgData := configData{
 		SiteName:     cfg.SiteName,
+		SiteDomain:   cfg.SiteDomain(),
 		SiteRootURL:  cfg.SiteRootURL,
 		SiteRootPath: cfg.SiteRootPath(),
 		AuthorName:   cfg.AuthorName,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,6 +42,19 @@ func (c Config) SiteRootPath() string {
 	return p
 }
 
+// SiteDomain returns the domain (host) component of SiteRootURL.
+func (c Config) SiteDomain() string {
+	idx := strings.Index(c.SiteRootURL, "://")
+	if idx < 0 {
+		return c.SiteRootURL
+	}
+	rest := c.SiteRootURL[idx+3:]
+	if slash := strings.IndexByte(rest, '/'); slash >= 0 {
+		return rest[:slash]
+	}
+	return rest
+}
+
 // FeedURL returns the full feed URL.
 func (c Config) FeedURL() string {
 	return strings.TrimRight(c.SiteRootURL, "/") + c.FeedPath()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,6 +21,8 @@ type Config struct {
 	SiteRootURL string `yaml:"site_root_url"`
 	SiteName    string `yaml:"site_name"`
 	AuthorName  string `yaml:"author_name"`
+	LicenseName string `yaml:"license_name"`
+	LicenseURL  string `yaml:"license_url"`
 }
 
 // SiteRootPath returns the URL path component of SiteRootURL.
@@ -82,13 +84,15 @@ func Load(yamlPath string, flagOverrides map[string]string) (Config, error) {
 	}
 
 	flagMap := map[string]*string{
-		"notes":  &cfg.NotesPath,
-		"assets": &cfg.AssetsPath,
-		"out":         &cfg.BuildPath,
-		"static":      &cfg.StaticPath,
-		"url":         &cfg.SiteRootURL,
-		"site-name":   &cfg.SiteName,
-		"author":      &cfg.AuthorName,
+		"notes":        &cfg.NotesPath,
+		"assets":       &cfg.AssetsPath,
+		"out":          &cfg.BuildPath,
+		"static":       &cfg.StaticPath,
+		"url":          &cfg.SiteRootURL,
+		"site-name":    &cfg.SiteName,
+		"author":       &cfg.AuthorName,
+		"license-name": &cfg.LicenseName,
+		"license-url":  &cfg.LicenseURL,
 	}
 	for flagKey, ptr := range flagMap {
 		if v, ok := flagOverrides[flagKey]; ok && v != "" {
@@ -105,6 +109,13 @@ func Load(yamlPath string, flagOverrides map[string]string) (Config, error) {
 	}
 	if cfg.AssetsPath == "" && cfg.NotesPath != "" {
 		cfg.AssetsPath = filepath.Join(cfg.NotesPath, "images")
+	}
+
+	if cfg.LicenseName == "" {
+		cfg.LicenseName = "CC BY 4.0"
+	}
+	if cfg.LicenseURL == "" {
+		cfg.LicenseURL = "https://creativecommons.org/licenses/by/4.0/"
 	}
 
 	if cfg.SiteRootURL == "" {

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -26,7 +26,7 @@
     <footer>
       <hr class="!my-6">
       <p class="not-prose text-slate-400">
-        {{if .Page.PublishedAt}}<time datetime="{{.Page.PublishedAtISO}}">{{.Page.PublishedAtFormatted}}</time> &middot; {{end}}<a href="{{.Config.FeedPath}}">RSS</a>
+        {{if .Page.PublishedAt}}<time datetime="{{.Page.PublishedAtISO}}">{{.Page.PublishedAtFormatted}}</time> &middot; {{end}}{{.Config.SiteDomain}} &middot; <a href="{{.Config.FeedPath}}">RSS</a> &middot; <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>
       </p>
     </footer>
   </div>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -26,7 +26,7 @@
     <footer>
       <hr class="!my-6">
       <p class="not-prose text-slate-400">
-        {{if .Page.PublishedAt}}<time datetime="{{.Page.PublishedAtISO}}">{{.Page.PublishedAtFormatted}}</time> &middot; {{end}}{{.Config.SiteDomain}} &middot; <a href="{{.Config.FeedPath}}">RSS</a> &middot; <a href="https://creativecommons.org/licenses/by/4.0/">CC BY 4.0</a>
+        {{if .Page.PublishedAt}}<time datetime="{{.Page.PublishedAtISO}}">{{.Page.PublishedAtFormatted}}</time> &middot; {{end}}{{.Config.SiteDomain}} &middot; <a href="{{.Config.FeedPath}}">RSS</a> &middot; <a href="{{.Config.LicenseURL}}">{{.Config.LicenseName}}</a>
       </p>
     </footer>
   </div>


### PR DESCRIPTION
## Summary
- Add `SiteDomain()` method to extract host from `SiteRootURL`
- Display site domain and CC BY 4.0 license link in the page footer
- Footer items separated by middots: date · domain · RSS · CC BY 4.0

## Test plan
- [x] All existing tests pass
- [x] Verify footer renders correctly on published pages
- [x] Verify footer renders correctly on pages without a date