### PR TITLE
Default build_path and notes_path fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ All values can be overridden with CLI flags:
 
 | Config option | CLI flag | Default |
 |---|---|---|
-| `notes_path` | `--notes` | |
+| `notes_path` | `--notes` | `$NOTES_PATH` |
 | `assets_path` | `--assets` | `<notes_path>/images` |
-| `build_path` | `--out` | |
+| `build_path` | `--out` | `./dist` |
 | `static_path` | `--static` | `<notes_path>/static` |
 | `site_root_url` | `--url` | |
 | `site_name` | `--site-name` | |

--- a/README.md
+++ b/README.md
@@ -32,17 +32,17 @@ author_name: "Ada Lovelace"
 
 All values can be overridden with CLI flags:
 
-| Config option | CLI flag | Default |
-|---|---|---|
-| `notes_path` | `--notes` | `$NOTES_PATH` |
-| `assets_path` | `--assets` | `<notes_path>/images` |
-| `build_path` | `--out` | `./dist` |
-| `static_path` | `--static` | `<notes_path>/static` |
-| `site_root_url` | `--url` | |
-| `site_name` | `--site-name` | |
-| `author_name` | `--author` | |
-| `license_name` | `--license-name` | CC BY 4.0 |
-| `license_url` | `--license-url` | https://creativecommons.org/licenses/by/4.0/ |
+| Config option | CLI flag | Default | Required |
+|---|---|---|---|
+| `notes_path` | `--notes` | `$NOTES_PATH` | |
+| `assets_path` | `--assets` | `<notes_path>/images` | |
+| `build_path` | `--out` | `./dist` | |
+| `static_path` | `--static` | `<notes_path>/static` | |
+| `site_root_url` | `--url` | | Yes |
+| `site_name` | `--site-name` | | Yes |
+| `author_name` | `--author` | | Yes |
+| `license_name` | `--license-name` | CC BY 4.0 | |
+| `license_url` | `--license-url` | https://creativecommons.org/licenses/by/4.0/ | |
 
 Priority: CLI flags > YAML config.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -100,8 +100,14 @@ func Load(yamlPath string, flagOverrides map[string]string) (Config, error) {
 		}
 	}
 
+	if cfg.NotesPath == "" {
+		cfg.NotesPath = os.Getenv("NOTES_PATH")
+	}
 	cfg.NotesPath = expandHome(cfg.NotesPath)
 	cfg.AssetsPath = expandHome(cfg.AssetsPath)
+	if cfg.BuildPath == "" {
+		cfg.BuildPath = "./dist"
+	}
 	cfg.BuildPath = expandHome(cfg.BuildPath)
 	cfg.StaticPath = expandHome(cfg.StaticPath)
 	if cfg.StaticPath == "" && cfg.NotesPath != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -116,6 +116,54 @@ author_name: "Test Author"
 	}
 }
 
+func TestBuildPathDefaultsToDist(t *testing.T) {
+	dir := t.TempDir()
+	yamlPath := filepath.Join(dir, DefaultConfigFile)
+	err := os.WriteFile(yamlPath, []byte(`
+notes_path: "/tmp/notes"
+site_root_url: "https://example.com"
+site_name: "Test Site"
+author_name: "Test Author"
+`), 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(yamlPath, nil)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if cfg.BuildPath != "./dist" {
+		t.Errorf("BuildPath = %q, want ./dist", cfg.BuildPath)
+	}
+}
+
+func TestNotesPathDefaultsToEnvVar(t *testing.T) {
+	dir := t.TempDir()
+	yamlPath := filepath.Join(dir, DefaultConfigFile)
+	err := os.WriteFile(yamlPath, []byte(`
+build_path: "./dist"
+site_root_url: "https://example.com"
+site_name: "Test Site"
+author_name: "Test Author"
+`), 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("NOTES_PATH", "/env/notes")
+
+	cfg, err := Load(yamlPath, nil)
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if cfg.NotesPath != "/env/notes" {
+		t.Errorf("NotesPath = %q, want /env/notes", cfg.NotesPath)
+	}
+}
+
 func TestExpandHomePath(t *testing.T) {
 	dir := t.TempDir()
 	yamlPath := filepath.Join(dir, DefaultConfigFile)


### PR DESCRIPTION
## Summary
- Default `build_path` to `./dist` when not set in config or CLI flags
- Fall back to `$NOTES_PATH` env var for `notes_path` (shared with notescli)
- Add Default and Required columns to config params table in README

## Test plan
- [x] All existing tests pass
- [x] Verify build uses `./dist` when `build_path` is omitted
- [x] Verify `NOTES_PATH` env var is picked up when `notes_path` is omitted