### PR TITLE
Add GitHub PR template and auto-tag workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+## Summary
+
+-
+
+## References
+
+- Closes #

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,29 @@
+name: Auto-tag on PR merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  tag:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Bump patch version and push tag
+        run: |
+          LATEST=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          if [ -z "$LATEST" ]; then
+            NEXT="v0.1.0"
+          else
+            PATCH=$(echo "$LATEST" | cut -d. -f3)
+            NEXT="v0.1.$((PATCH + 1))"
+          fi
+          git tag "$NEXT"
+          git push origin "$NEXT"
+          echo "Tagged $NEXT"


### PR DESCRIPTION
## Summary

- Add PR template with Summary and References sections
- Add GitHub Actions workflow to auto-bump patch version and push tag on PR merge to main

## References

- Replicated from [notescli](https://github.com/dreikanter/notescli)