### PR TITLE
Move publication date from footer to post content

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -44,12 +44,9 @@ type configData struct {
 
 // pageData holds metadata for the layout template.
 type pageData struct {
-	Title              string
-	MetaDescription    string
-	CanonicalPath      string
-	PublishedAt        *time.Time
-	PublishedAtISO     string
-	PublishedAtFormatted string
+	Title           string
+	MetaDescription string
+	CanonicalPath   string
 }
 
 // noteData is the data passed to note.html inner template.
@@ -300,12 +297,9 @@ func Build(cfg config.Config, templateFS fs.FS, styleCSS []byte) error {
 		}
 
 		pd := pageData{
-			Title:              np.Title,
-			MetaDescription:    np.Description,
-			CanonicalPath:      np.CanonicalPath(),
-			PublishedAt:        &np.PublishedAt,
-			PublishedAtISO:     np.PublishedAt.Format("2006-01-02"),
-			PublishedAtFormatted: np.PublishedAt.Format("2 January 2006"),
+			Title:           np.Title,
+			MetaDescription: np.Description,
+			CanonicalPath:   np.CanonicalPath(),
 		}
 
 		if err := writeHTMLPage(tmpl, cfg.BuildPath, np.LocalPath(), "note.html", inner, cfgData, pd); err != nil {

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -26,7 +26,7 @@
     <footer>
       <hr class="!my-6">
       <p class="not-prose text-slate-400">
-        {{if .Page.PublishedAt}}<time datetime="{{.Page.PublishedAtISO}}">{{.Page.PublishedAtFormatted}}</time> &middot; {{end}}{{.Config.SiteDomain}} &middot; <a href="{{.Config.FeedPath}}">RSS</a> &middot; <a href="{{.Config.LicenseURL}}">{{.Config.LicenseName}}</a>
+        {{.Config.SiteDomain}} &middot; <a href="{{.Config.FeedPath}}">RSS</a> &middot; <a href="{{.Config.LicenseURL}}">{{.Config.LicenseName}}</a>
       </p>
     </footer>
   </div>

--- a/templates/note.html
+++ b/templates/note.html
@@ -2,16 +2,10 @@
 
 {{.Note.Body}}
 
-<p class="text-slate-400"><time datetime="{{.Note.PublishedAt.Format "2006-01-02"}}">{{.Note.PublishedAt.Format "2 January 2006"}}</time></p>
-
-{{if .Note.Tags}}
-  <hr class="!my-6">
-  <div class="flex flex-row flex-wrap items-stretch !my-6">
-    {{range .Note.Tags}}
-      <a href="/tags/{{.}}" class="block border rounded-md py-0 px-2 my-1 mr-2 no-underline font-normal bg-slate-100 !text-slate-800 border-slate-200">{{.}}</a>
-    {{end}}
-  </div>
-{{end}}
+<div class="not-prose flex flex-row flex-wrap items-baseline gap-2 text-slate-400" style="margin-top:3rem">
+  <time datetime="{{.Note.PublishedAt.Format "2006-01-02"}}">{{.Note.PublishedAt.Format "2 January 2006"}}</time>{{if .Note.Tags}}<span>&middot;</span>{{range .Note.Tags}}
+  <a href="/tags/{{.}}" class="border rounded-md py-0 px-2 no-underline font-normal bg-slate-100 !text-slate-800 border-slate-200">{{.}}</a>{{end}}{{end}}
+</div>
 
 {{if .Related}}
   <hr class="!my-6">

--- a/templates/note.html
+++ b/templates/note.html
@@ -2,6 +2,8 @@
 
 {{.Note.Body}}
 
+<p class="text-slate-400"><time datetime="{{.Note.PublishedAt.Format "2006-01-02"}}">{{.Note.PublishedAt.Format "2 January 2006"}}</time></p>
+
 {{if .Note.Tags}}
   <hr class="!my-6">
   <div class="flex flex-row flex-wrap items-stretch !my-6">


### PR DESCRIPTION
## Summary

- Move the publication date from the page footer to the end of the post body
- Display date and tags inline on the same line, separated by a middot
- Date and tags are muted (`text-slate-400`) with aligned baselines
- Clean up unused `PublishedAt` fields from `pageData` struct

## Test plan

- [x] `make build && ./notespub build && ./notespub serve`
- [x] Post pages show date and tags inline after the body
- [x] Footer no longer contains the date
- [x] Posts without tags show only the date (no middot)
- [x] Non-post pages (index, tag pages) render correctly