### PR TITLE
Switch auto-tag workflow to CHANGELOG-driven versioning

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -15,14 +15,17 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - name: Bump patch version and push tag
+      - name: Tag from CHANGELOG
         run: |
-          LATEST=$(git tag --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
-          if [ -z "$LATEST" ]; then
-            NEXT="v0.1.0"
-          else
-            PATCH=$(echo "$LATEST" | cut -d. -f3)
-            NEXT="v0.1.$((PATCH + 1))"
+          VERSION=$(grep -m1 -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | tr -d '[]' | awk '{print $2}')
+          if [ -z "$VERSION" ]; then
+            echo "No version heading found in CHANGELOG.md" >&2
+            exit 1
+          fi
+          NEXT="v$VERSION"
+          if git rev-parse -q --verify "refs/tags/$NEXT" >/dev/null; then
+            echo "Tag $NEXT already exists; skipping"
+            exit 0
           fi
           git tag "$NEXT"
           git push origin "$NEXT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [0.1.7] - 2026-04-24
+
+### Changed
+
+- `.github/workflows/tag.yml` now tags merged PRs using the topmost `## [X.Y.Z]` heading from `CHANGELOG.md` instead of auto-incrementing the patch off the latest git tag. Bump major/minor/patch by writing the desired heading in the PR.

--- a/README.md
+++ b/README.md
@@ -81,3 +81,10 @@ The `serve` command starts a local HTTP server on port 4000 (override with `--po
 ## Notes format
 
 Notes are Markdown files managed by [notes-cli](https://github.com/dreikanter/notes-cli). A note becomes part of the published site when its frontmatter includes `public: true`.
+
+## Versioning
+
+`CHANGELOG.md` is the source of truth for the version. On PR merge, GitHub
+Actions (`.github/workflows/tag.yml`) reads the topmost `## [X.Y.Z]` heading
+from `CHANGELOG.md` and pushes `vX.Y.Z` as a git tag. Bump major/minor/patch
+by writing the desired heading in the PR.


### PR DESCRIPTION
## Summary

- Replace `.github/workflows/tag.yml` with the notes-cli variant that reads the topmost `## [X.Y.Z]` heading from `CHANGELOG.md` instead of auto-incrementing the patch off the latest git tag. Major/minor/patch bumps are now selected by writing the desired heading in a PR.
- Seed `CHANGELOG.md` with `## [0.1.7] - 2026-04-24` (continues the existing `v0.1.6` tag line).
- Document the release flow in a new "Versioning" section of `README.md`.

## Test plan

- [x] After merge, confirm the `tag.yml` run extracts `0.1.7` from `CHANGELOG.md` and pushes `v0.1.7`.
- [x] Open a follow-up PR that bumps the heading to `0.1.8`; confirm the workflow tags `v0.1.8` on merge.
- [x] Open a PR that does not touch `CHANGELOG.md` (heading unchanged); confirm the workflow logs "Tag vX.Y.Z already exists; skipping" and exits 0.