### PR TITLE
Adopt notes-cli v0.3.20 Store interface

### DIFF
--- a/cmd/notespub/main.go
+++ b/cmd/notespub/main.go
@@ -9,6 +9,7 @@ import (
 	"runtime/debug"
 	"strings"
 
+	"github.com/dreikanter/notes-cli/note"
 	notespub "github.com/dreikanter/notes-pub"
 	"github.com/dreikanter/notes-pub/internal/build"
 	"github.com/dreikanter/notes-pub/internal/config"
@@ -40,7 +41,8 @@ var buildCmd = &cobra.Command{
 		}
 
 		log.Printf("building site from %s to %s", cfg.NotesPath, cfg.BuildPath)
-		if err := build.Build(cfg, notespub.TemplateFS, notespub.StyleCSS); err != nil {
+		store := note.NewOSStore(cfg.NotesPath)
+		if err := build.Build(store, cfg, notespub.TemplateFS, notespub.StyleCSS); err != nil {
 			return fmt.Errorf("build failed: %w", err)
 		}
 		log.Println("build complete")

--- a/docs/superpowers/plans/2026-04-24-notes-cli-store-refactor.md
+++ b/docs/superpowers/plans/2026-04-24-notes-cli-store-refactor.md
@@ -1,0 +1,975 @@
+# notes-cli Store Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace notes-pub's direct use of `notes-cli` v0.1.66 free functions (`note.Scan`, `note.ParseFrontmatterFields`, `note.StripFrontmatter`) with the v0.3.20 `note.Store` interface. `Build` takes a `note.Store` explicitly; build tests migrate to `note.MemStore`.
+
+**Architecture:** `cmd/notespub/main.go` constructs a `note.OSStore` rooted at `cfg.NotesPath` and passes it into `build.Build`. Inside `Build`, one `store.All(note.WithPublic(true))` call replaces the scan+read+parse+filter loop. A new `buildNotePages` helper converts `[]note.Entry` → `[]page.NotePage` + `map[int]string` note index. `render.Render` is retyped to take `string` body and `map[int]string` index.
+
+**Tech Stack:** Go 1.25+, `github.com/dreikanter/notes-cli` v0.3.20, `github.com/yuin/goldmark`, `github.com/spf13/cobra`.
+
+---
+
+## Spec reference
+
+See `docs/superpowers/specs/2026-04-24-notes-cli-store-refactor-design.md` for the full design. This plan implements it.
+
+## File Structure
+
+Files created: none.
+
+Files modified:
+
+- `go.mod`, `go.sum` — bump `notes-cli` to v0.3.20; `go mod tidy` pulls new transitive deps.
+- `internal/render/render.go` — signature change: `source []byte` → `source string`, `noteIndex map[string]string` → `noteIndex map[int]string`. Internal `strconv.Atoi` lookup for markdown link targets.
+- `internal/render/render_test.go` — update map literal from `"8823"` key to `8823` key.
+- `internal/build/build.go` — swap read path to `store.All(note.WithPublic(true))`; extract `buildNotePages`, `chooseSlug`, `titleOrUID`; delete `parseDate`, `trimQuotes`, `trimQuotesList`, `cleanTitle`, `parsedNote`; change `Build` signature to take `note.Store`.
+- `internal/build/build_test.go` — migrate three Build tests to `note.MemStore`; drop `writeTestNote` and filesystem fixtures; `testConfig` loses the `notesPath` argument.
+- `cmd/notespub/main.go` — construct `note.NewOSStore(cfg.NotesPath)` and pass it to `build.Build`.
+
+## Pre-flight
+
+- [ ] **Step 0.1: Verify clean working tree**
+
+```bash
+git status
+```
+
+Expected: `nothing to commit, working tree clean` (or only the committed spec file).
+
+- [ ] **Step 0.2: Run existing tests — establish green baseline**
+
+```bash
+go test ./...
+```
+
+Expected: all tests pass. If any fail, stop and investigate before starting — the plan assumes the pre-swap codebase is green.
+
+---
+
+## Task 1: Bump notes-cli to v0.3.20
+
+**Files:**
+- Modify: `go.mod`
+- Modify: `go.sum`
+
+- [ ] **Step 1.1: Bump the dependency**
+
+```bash
+go get github.com/dreikanter/notes-cli@v0.3.20
+```
+
+Expected output includes a line like `go: upgraded github.com/dreikanter/notes-cli v0.1.66 => v0.3.20`.
+
+- [ ] **Step 1.2: Tidy the module**
+
+```bash
+go mod tidy
+```
+
+Expected: `go.sum` updated; `go.mod` should now list `golang.org/x/sync` as a new transitive dep (used by `OSStore.readConcurrent`).
+
+- [ ] **Step 1.3: Verify the dependency is in place**
+
+```bash
+grep notes-cli go.mod
+```
+
+Expected: `github.com/dreikanter/notes-cli v0.3.20` on the `require` line.
+
+- [ ] **Step 1.4: Confirm the build currently fails (expected)**
+
+```bash
+go build ./...
+```
+
+Expected: build errors in `internal/build/build.go` complaining about `note.Scan`, `note.Note`, `note.ParseFrontmatterFields`, `note.StripFrontmatter`, or their types — these are the API calls that have moved under `note.Store` in v0.3.20.
+
+**Do not attempt to fix them in this task** — subsequent tasks replace these call sites. Commit the dependency bump with the known build break; the next tasks restore green.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add go.mod go.sum
+git commit -m "deps: bump notes-cli to v0.3.20 (Store interface)"
+```
+
+---
+
+## Task 2: Update render.Render signature (string body + int-keyed note index)
+
+**Files:**
+- Modify: `internal/render/render.go:41` (function signature and body)
+- Modify: `internal/render/render.go:60` (text.NewReader call)
+- Modify: `internal/render/render.go:96` (md.Renderer().Render call)
+- Modify: `internal/render/render_test.go:34` (map literal key type)
+
+The `render` package has no dependency on `note`, so this task compiles and tests green on its own. Doing it before `build.go` keeps the compile-red surface small.
+
+- [ ] **Step 2.1: Update render_test.go first (failing test)**
+
+Change `internal/render/render_test.go:33-45`:
+
+```go
+func TestRenderNoteLink(t *testing.T) {
+	noteIndex := map[int]string{
+		8823: "20260106_8823/some-slug",
+	}
+	md := "See [this note](8823)\n"
+	html, err := Render(md, noteIndex, nil)
+	if err != nil {
+		t.Fatalf("Render() error: %v", err)
+	}
+	if !strings.Contains(string(html), `href="/20260106_8823/some-slug"`) {
+		t.Errorf("expected resolved link, got: %s", html)
+	}
+}
+```
+
+Also update the remaining `Render(...)` calls in the same file to pass a `string` instead of `[]byte(md)`:
+
+- `internal/render/render_test.go:10` → `Render(md, nil, nil)`
+- `internal/render/render_test.go:24` → `Render(md, nil, nil)`
+- `internal/render/render_test.go:38` → already updated above
+- `internal/render/render_test.go:49` → `Render(md, nil, nil)`
+- `internal/render/render_test.go:60` → `Render(md, nil, nil)`
+- `internal/render/render_test.go:71` → `Render(md, nil, nil)`
+- `internal/render/render_test.go:82` → `Render(md, nil, nil)`
+- `internal/render/render_test.go:98` → `Render(md, nil, processImage)`
+
+All eight call sites pass `md` (a `string`) directly, no `[]byte(...)` wrapping.
+
+- [ ] **Step 2.2: Run render tests to confirm they fail to compile**
+
+```bash
+go test ./internal/render/ -run TestRenderNoteLink -v
+```
+
+Expected: compile error — `Render` still expects `[]byte` and `map[string]string`.
+
+- [ ] **Step 2.3: Update render.go signature**
+
+Replace `internal/render/render.go:38-100` with:
+
+```go
+// Render converts Markdown to HTML.
+// noteIndex maps note IDs to their public paths (for link resolution).
+// processImage is called for external image URLs (may be nil).
+func Render(source string, noteIndex map[int]string, processImage ProcessImageFunc) ([]byte, error) {
+	md := goldmark.New(
+		goldmark.WithExtensions(
+			extension.GFM,
+			highlighting.NewHighlighting(
+				highlighting.WithStyle("monokailight"),
+				highlighting.WithGuessLanguage(true),
+				highlighting.WithCSSWriter(nil),
+				highlighting.WithFormatOptions(
+					chromahtml.WithClasses(true),
+					chromahtml.WithPreWrapper(chromaPreWrapper{}),
+				),
+			),
+		),
+		goldmark.WithParserOptions(
+			parser.WithAutoHeadingID(),
+		),
+	)
+
+	sourceBytes := []byte(source)
+	reader := text.NewReader(sourceBytes)
+	doc := md.Parser().Parse(reader)
+
+	// Walk AST and transform links and images.
+	err := ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if !entering {
+			return ast.WalkContinue, nil
+		}
+
+		switch node := n.(type) {
+		case *ast.Link:
+			dest := string(node.Destination)
+			if isNoteID(dest) && noteIndex != nil {
+				id, err := strconv.Atoi(dest)
+				if err == nil {
+					if resolved, ok := noteIndex[id]; ok {
+						node.Destination = []byte("/" + resolved)
+					}
+				}
+			}
+
+		case *ast.Image:
+			src := string(node.Destination)
+			if processImage != nil && isExternalURL(src) {
+				localName, err := processImage(src)
+				if err != nil {
+					return ast.WalkContinue, nil
+				}
+				node.Destination = []byte(localName)
+			}
+		}
+
+		return ast.WalkContinue, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	if err := md.Renderer().Render(&buf, sourceBytes, doc); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+```
+
+Add `"strconv"` to the import block in `internal/render/render.go:3-17`. The block becomes:
+
+```go
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"strconv"
+
+	chromahtml "github.com/alecthomas/chroma/v2/formatters/html"
+	"github.com/alecthomas/chroma/v2/styles"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/extension"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+
+	highlighting "github.com/yuin/goldmark-highlighting/v2"
+)
+```
+
+- [ ] **Step 2.4: Run render tests to verify green**
+
+```bash
+go test ./internal/render/ -v
+```
+
+Expected: all seven `TestRender*` tests pass, including the updated `TestRenderNoteLink` and `TestRenderNoteLinkUnresolved`.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add internal/render/render.go internal/render/render_test.go
+git commit -m "render: accept string source and int-keyed note index"
+```
+
+---
+
+## Task 3: Swap Build's read path to note.Store
+
+**Files:**
+- Modify: `internal/build/build.go:16` (import)
+- Modify: `internal/build/build.go:165-254` (Build function — signature, read path, page construction, render loop)
+- Modify: `internal/build/build.go:462-505` (delete obsolete helpers)
+- Modify: `cmd/notespub/main.go:43` (Build call site)
+
+This is the central task. It changes `Build`'s signature, replaces the scan+ReadFile loop, extracts the `buildNotePages` helper, and updates the render loop to use `int` IDs. The test file is migrated in Task 4.
+
+- [ ] **Step 3.1: Update imports in internal/build/build.go**
+
+Replace `internal/build/build.go:3-21` with:
+
+```go
+import (
+	"fmt"
+	"html/template"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	texttemplate "text/template"
+
+	"github.com/dreikanter/notes-cli/note"
+	"github.com/dreikanter/notes-pub/internal/config"
+	"github.com/dreikanter/notes-pub/internal/images"
+	"github.com/dreikanter/notes-pub/internal/page"
+	"github.com/dreikanter/notes-pub/internal/render"
+)
+```
+
+(`time` stays — used for `PublishedAt`; `strconv` is new — used to stringify int IDs.)
+
+- [ ] **Step 3.2: Replace the Build function body**
+
+Replace `internal/build/build.go:165-396` (the entire `Build` function) with:
+
+```go
+// Build generates the static site from notes.
+func Build(store note.Store, cfg config.Config, templateFS fs.FS, styleCSS []byte) error {
+	// 0. Clean build directory.
+	if err := cleanBuildDir(cfg.BuildPath); err != nil {
+		return err
+	}
+
+	// 0b. Copy static files.
+	if cfg.StaticPath != "" {
+		if err := copyStaticFiles(cfg.StaticPath, cfg.BuildPath); err != nil {
+			return fmt.Errorf("copying static files: %w", err)
+		}
+	}
+
+	// 1. Read public notes from the store.
+	entries, err := store.All(note.WithPublic(true))
+	if err != nil {
+		return fmt.Errorf("reading notes: %w", err)
+	}
+
+	// 2. Build note-page models and the ID → public-path index.
+	notePages, noteIndex := buildNotePages(entries, cfg.SiteRootURL)
+
+	// 3. Render Markdown for each note (now that noteIndex is complete).
+	imgCache := images.NewCache(cfg.AssetsPath)
+	for i, e := range entries {
+		uid := notePages[i].UID
+		processImage := func(src string) (string, error) {
+			entry, err := imgCache.Get(src, uid)
+			if err != nil {
+				return "", err
+			}
+			notePages[i].Attachments = append(notePages[i].Attachments, page.Attachment{
+				FileName: entry.FileName,
+				PageUID:  entry.PageUID,
+			})
+			return entry.FileName, nil
+		}
+		rendered, err := render.Render(e.Body, noteIndex, processImage)
+		if err != nil {
+			return fmt.Errorf("rendering note %d: %w", e.ID, err)
+		}
+		notePages[i].Body = string(rendered)
+	}
+
+	// 4. Sort pages newest first (defensive — store already returns newest-first).
+	page.SortNotePages(notePages)
+
+	// 5. Load templates.
+	tmpl, err := template.New("").ParseFS(templateFS, "templates/*.html")
+	if err != nil {
+		return fmt.Errorf("parsing HTML templates: %w", err)
+	}
+
+	// Parse feed.xml with text/template (no HTML escaping).
+	feedTmpl, err := texttemplate.New("").ParseFS(templateFS, "templates/feed.xml")
+	if err != nil {
+		return fmt.Errorf("parsing feed template: %w", err)
+	}
+
+	cfgData := configData{
+		SiteName:     cfg.SiteName,
+		SiteDomain:   cfg.SiteDomain(),
+		SiteRootURL:  cfg.SiteRootURL,
+		SiteRootPath: cfg.SiteRootPath(),
+		AuthorName:   cfg.AuthorName,
+		FeedURL:      cfg.FeedURL(),
+		FeedPath:     cfg.FeedPath(),
+		LicenseName:  cfg.LicenseName,
+		LicenseURL:   cfg.LicenseURL,
+		StyleCSS:     template.CSS(styleCSS),
+		HighlightCSS: template.CSS(render.HighlightCSS()),
+	}
+
+	// 6. Write note pages and redirects.
+	for _, np := range notePages {
+		nvd := toNoteViewData(np)
+
+		// Find related notes.
+		relatedPages := page.RelatedTo(notePages, np)
+		var relatedViews []noteViewData
+		for _, rp := range relatedPages {
+			relatedViews = append(relatedViews, toNoteViewData(rp))
+		}
+
+		inner := noteData{
+			Note:    nvd,
+			Related: relatedViews,
+		}
+
+		pd := pageData{
+			Title:           np.Title,
+			MetaDescription: np.Description,
+			CanonicalPath:   np.CanonicalPath(),
+		}
+
+		if err := writeHTMLPage(tmpl, cfg.BuildPath, np.LocalPath(), "note.html", inner, cfgData, pd); err != nil {
+			return fmt.Errorf("writing note page %s: %w", np.UID, err)
+		}
+
+		// Copy attachments.
+		for _, att := range np.Attachments {
+			destDir := filepath.Join(cfg.BuildPath, np.UID, np.Slug)
+			if err := imgCache.CopyTo(images.Entry{FileName: att.FileName, PageUID: att.PageUID}, destDir); err != nil {
+				return fmt.Errorf("copying attachment %s: %w", att.FileName, err)
+			}
+		}
+
+		// Write redirect page.
+		rp := page.RedirectPage{
+			UID:        np.UID,
+			RedirectTo: "/" + np.PublicPath(),
+		}
+		if err := writeRedirectPage(tmpl, cfg.BuildPath, rp); err != nil {
+			return fmt.Errorf("writing redirect page %s: %w", np.UID, err)
+		}
+	}
+
+	// 7. Write index page.
+	allTags := page.AllTags(notePages)
+	var noteViews []noteViewData
+	for _, np := range notePages {
+		noteViews = append(noteViews, toNoteViewData(np))
+	}
+
+	indexInner := indexData{
+		Tags:      allTags,
+		NotePages: noteViews,
+	}
+	indexPD := pageData{
+		Title:           "",
+		MetaDescription: cfg.SiteName,
+	}
+	if err := writeHTMLPage(tmpl, cfg.BuildPath, "index.html", "index.html", indexInner, cfgData, indexPD); err != nil {
+		return fmt.Errorf("writing index page: %w", err)
+	}
+
+	// 8. Write tag pages.
+	for _, tag := range allTags {
+		tagged := page.TaggedPages(notePages, tag)
+		var taggedViews []noteViewData
+		for _, tp := range tagged {
+			taggedViews = append(taggedViews, toNoteViewData(tp))
+		}
+		tagInner := tagData{
+			Tags:        allTags,
+			CurrentTag:  tag,
+			TaggedPages: taggedViews,
+		}
+		tp := page.TagPage{Tag: tag}
+		tagPD := pageData{
+			Title:           tag,
+			MetaDescription: fmt.Sprintf("Notes tagged with %s", tag),
+			CanonicalPath:   tp.CanonicalPath(),
+		}
+		if err := writeHTMLPage(tmpl, cfg.BuildPath, tp.LocalPath(), "tag.html", tagInner, cfgData, tagPD); err != nil {
+			return fmt.Errorf("writing tag page %s: %w", tag, err)
+		}
+	}
+
+	// 9. Write feed.
+	var feedNotes []feedNoteData
+	for _, np := range notePages {
+		feedNotes = append(feedNotes, feedNoteData{
+			Title: np.Title,
+			URL:   np.URL(),
+			UID:   np.UID,
+			Body:  np.Body,
+		})
+	}
+	fd := feedData{
+		Config:    cfgData,
+		NotePages: feedNotes,
+	}
+	if err := writeFile(cfg.BuildPath, "feed.xml", func() ([]byte, error) {
+		var buf strings.Builder
+		if err := feedTmpl.ExecuteTemplate(&buf, "feed.xml", fd); err != nil {
+			return nil, err
+		}
+		return []byte(buf.String()), nil
+	}); err != nil {
+		return fmt.Errorf("writing feed: %w", err)
+	}
+
+	return nil
+}
+
+// buildNotePages converts note.Entry values into page.NotePage models and
+// builds the ID → public-path index used for link resolution.
+func buildNotePages(entries []note.Entry, siteRootURL string) ([]page.NotePage, map[int]string) {
+	pages := make([]page.NotePage, 0, len(entries))
+	index := make(map[int]string, len(entries))
+	for _, e := range entries {
+		uid := e.Meta.CreatedAt.Format("20060102") + "_" + strconv.Itoa(e.ID)
+		slug := chooseSlug(e, uid)
+		np := page.NotePage{
+			UID:         uid,
+			ShortUID:    strconv.Itoa(e.ID),
+			Slug:        slug,
+			Title:       titleOrUID(e.Meta.Title, uid),
+			Description: e.Meta.Description,
+			Tags:        e.Meta.Tags,
+			SiteRootURL: siteRootURL,
+			PublishedAt: e.Meta.CreatedAt,
+		}
+		index[e.ID] = np.PublicPath()
+		pages = append(pages, np)
+	}
+	return pages, index
+}
+
+// chooseSlug returns the slug to use for e, falling back from Meta.Slug to
+// slugified Meta.Title to the entry's ID.
+func chooseSlug(e note.Entry, uid string) string {
+	if s := slugify(e.Meta.Slug); s != "" {
+		return s
+	}
+	if s := slugify(e.Meta.Title); s != "" {
+		return s
+	}
+	return strconv.Itoa(e.ID)
+}
+
+// titleOrUID returns title when non-empty, otherwise uid as a fallback.
+func titleOrUID(title, uid string) string {
+	if title == "" {
+		return uid
+	}
+	return title
+}
+```
+
+**What's gone vs the old version:**
+
+- Lines 186–204 (the `parsedNote` struct, the `notes, err := note.Scan(...)` call, the per-note `os.ReadFile` + `ParseFrontmatterFields` + `StripFrontmatter` loop) — replaced by `store.All(note.WithPublic(true))` and `buildNotePages`.
+- Lines 206–233 (inline page construction with `trimQuotes`/`cleanTitle`/`parseDate`) — moved into `buildNotePages`.
+- The old `for i, pn := range publicNotes` render loop now reads `entries[i].Body` directly (a `string`), matching render.Render's new signature. `e.ID` (an int) is used for error messages and the `noteIndex` key.
+
+- [ ] **Step 3.3: Delete the obsolete helpers at the bottom of build.go**
+
+Delete these helper functions from `internal/build/build.go` (they are no longer called from anywhere):
+
+- `cleanTitle(title, fallback string) string` (around lines 472–479)
+- `trimQuotes(s string) string` (around lines 481–485)
+- `trimQuotesList(vals []string) []string` (around lines 487–494)
+- `parseDate(dateStr string) time.Time` (around lines 496–505)
+
+**Keep:** `slugify`, `toNoteViewData`, `writeHTMLPage`, `writeRedirectPage`, `writeFile`, `cleanBuildDir`, `copyStaticFiles`, the `nonAlphanumeric` regex — all still in use.
+
+After deletion, `time` is still imported (used by `PublishedAt` in `noteViewData`).
+
+- [ ] **Step 3.4: Update the call site in cmd/notespub/main.go**
+
+Replace `cmd/notespub/main.go:43` (inside `buildCmd.RunE`) with:
+
+```go
+			log.Printf("building site from %s to %s", cfg.NotesPath, cfg.BuildPath)
+			store := note.NewOSStore(cfg.NotesPath)
+			if err := build.Build(store, cfg, notespub.TemplateFS, notespub.StyleCSS); err != nil {
+				return fmt.Errorf("build failed: %w", err)
+			}
+```
+
+Add `"github.com/dreikanter/notes-cli/note"` to the import block at `cmd/notespub/main.go:3-16`:
+
+```go
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime/debug"
+	"strings"
+
+	"github.com/dreikanter/notes-cli/note"
+	notespub "github.com/dreikanter/notes-pub"
+	"github.com/dreikanter/notes-pub/internal/build"
+	"github.com/dreikanter/notes-pub/internal/config"
+	"github.com/spf13/cobra"
+)
+```
+
+- [ ] **Step 3.5: Verify build compiles**
+
+```bash
+go build ./...
+```
+
+Expected: no errors. If there are errors, they almost certainly concern `internal/build/build_test.go` (next task) — that test file has not been migrated yet and will fail to compile against the new `Build` signature.
+
+If `go build ./...` succeeds (tests are compiled by `go test`, not `go build`), move on. If `go test ./...` is run here it will fail at `internal/build/build_test.go` — expected, fixed in Task 4.
+
+- [ ] **Step 3.6: Run the render and config and page tests to make sure we didn't break anything adjacent**
+
+```bash
+go test ./internal/render/ ./internal/config/ ./internal/page/ ./internal/images/ -v
+```
+
+Expected: all pass. Build tests are not run here because they are in the middle of migration.
+
+- [ ] **Step 3.7: Commit**
+
+```bash
+git add internal/build/build.go cmd/notespub/main.go
+git commit -m "build: read notes via note.Store; extract buildNotePages helper"
+```
+
+---
+
+## Task 4: Migrate build tests to note.MemStore
+
+**Files:**
+- Modify: `internal/build/build_test.go` (entire `TestBuildPublicNote`, `TestBuildSkipsPrivateNote`, `TestBuildNoteLinkResolution`; helper `testConfig`; remove `writeTestNote`)
+
+The three tests currently write markdown files to `t.TempDir()` and pass the directory to `Build`. After migration they construct an in-memory `note.MemStore`, call `store.Put(entry)` for each note, and pass the store to `Build`.
+
+- [ ] **Step 4.1: Update imports and helpers**
+
+Replace `internal/build/build_test.go:1-10` with:
+
+```go
+package build
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dreikanter/notes-cli/note"
+	"github.com/dreikanter/notes-pub/internal/config"
+)
+```
+
+Delete the `writeTestNote` helper at `internal/build/build_test.go:99-108`. It is no longer needed.
+
+Change `testConfig` at `internal/build/build_test.go:110-120` to drop the `notesPath` parameter:
+
+```go
+func testConfig(t *testing.T, buildPath, assetsPath string) config.Config {
+	t.Helper()
+	return config.Config{
+		AssetsPath:  assetsPath,
+		BuildPath:   buildPath,
+		SiteRootURL: "https://example.com",
+		SiteName:    "Test Site",
+		AuthorName:  "Test Author",
+	}
+}
+```
+
+(`NotesPath` is gone from the config literal — `Build` no longer reads it directly.)
+
+- [ ] **Step 4.2: Migrate TestBuildPublicNote**
+
+Replace `internal/build/build_test.go:122-211` with:
+
+```go
+func TestBuildPublicNote(t *testing.T) {
+	buildDir := t.TempDir()
+	assetsDir := t.TempDir()
+
+	store := note.NewMemStore()
+	if _, err := store.Put(note.Entry{
+		ID: 3961,
+		Meta: note.Meta{
+			Title:     "My Test Note",
+			Slug:      "my-test-note",
+			Tags:      []string{"golang", "testing"},
+			Public:    true,
+			CreatedAt: time.Date(2023, 1, 30, 0, 0, 0, 0, time.UTC),
+		},
+		Body: "Hello **world**.\n",
+	}); err != nil {
+		t.Fatalf("store.Put: %v", err)
+	}
+
+	cfg := testConfig(t, buildDir, assetsDir)
+	templateFS := os.DirFS("../../")
+	styleCSS := []byte("/* test */")
+	if err := Build(store, cfg, templateFS, styleCSS); err != nil {
+		t.Fatalf("Build() error: %v", err)
+	}
+
+	// Check note page exists.
+	notePath := filepath.Join(buildDir, "20230130_3961", "my-test-note", "index.html")
+	data, err := os.ReadFile(notePath)
+	if err != nil {
+		t.Fatalf("note page not found: %v", err)
+	}
+	html := string(data)
+	if !strings.Contains(html, "My Test Note") {
+		t.Error("note page missing title")
+	}
+	if !strings.Contains(html, "<strong>world</strong>") {
+		t.Error("note page missing rendered body")
+	}
+
+	// Check redirect page exists.
+	redirectPath := filepath.Join(buildDir, "20230130_3961", "index.html")
+	rdata, err := os.ReadFile(redirectPath)
+	if err != nil {
+		t.Fatalf("redirect page not found: %v", err)
+	}
+	if !strings.Contains(string(rdata), "my-test-note") {
+		t.Error("redirect page missing slug in redirect URL")
+	}
+
+	// Check index page exists.
+	indexPath := filepath.Join(buildDir, "index.html")
+	idata, err := os.ReadFile(indexPath)
+	if err != nil {
+		t.Fatalf("index page not found: %v", err)
+	}
+	if !strings.Contains(string(idata), "My Test Note") {
+		t.Error("index page missing note title")
+	}
+
+	// Check tag page exists.
+	tagPath := filepath.Join(buildDir, "tags", "golang", "index.html")
+	if _, err := os.Stat(tagPath); err != nil {
+		t.Errorf("tag page not found: %v", err)
+	}
+
+	// Check feed exists.
+	feedPath := filepath.Join(buildDir, "feed.xml")
+	fdata, err := os.ReadFile(feedPath)
+	if err != nil {
+		t.Fatalf("feed not found: %v", err)
+	}
+	if !strings.Contains(string(fdata), "My Test Note") {
+		t.Error("feed missing note title")
+	}
+
+	// Check style.css is NOT written to disk (inlined into HTML instead).
+	stylePath := filepath.Join(buildDir, "style.css")
+	if _, err := os.Stat(stylePath); !os.IsNotExist(err) {
+		t.Errorf("style.css should not be written to build dir (CSS is inlined), got err: %v", err)
+	}
+
+	// Check CSS is inlined into HTML.
+	indexData, err := os.ReadFile(filepath.Join(buildDir, "index.html"))
+	if err != nil {
+		t.Fatalf("reading index.html: %v", err)
+	}
+	if !strings.Contains(string(indexData), "/* test */") {
+		t.Error("index.html should contain inlined styleCSS")
+	}
+	if strings.Contains(string(indexData), `href="/style.css"`) {
+		t.Error("index.html should not reference external /style.css")
+	}
+}
+```
+
+- [ ] **Step 4.3: Migrate TestBuildSkipsPrivateNote**
+
+Replace `internal/build/build_test.go:213-246` with:
+
+```go
+func TestBuildSkipsPrivateNote(t *testing.T) {
+	buildDir := t.TempDir()
+	assetsDir := t.TempDir()
+
+	store := note.NewMemStore()
+	if _, err := store.Put(note.Entry{
+		ID: 3961,
+		Meta: note.Meta{
+			Title:     "Private Note",
+			Tags:      []string{"secret"},
+			Public:    false,
+			CreatedAt: time.Date(2023, 1, 30, 0, 0, 0, 0, time.UTC),
+		},
+		Body: "This is private.\n",
+	}); err != nil {
+		t.Fatalf("store.Put: %v", err)
+	}
+
+	cfg := testConfig(t, buildDir, assetsDir)
+	templateFS := os.DirFS("../../")
+	styleCSS := []byte("/* test */")
+	if err := Build(store, cfg, templateFS, styleCSS); err != nil {
+		t.Fatalf("Build() error: %v", err)
+	}
+
+	notePath := filepath.Join(buildDir, "20230130_3961", "private-note", "index.html")
+	if _, err := os.Stat(notePath); err == nil {
+		t.Error("private note should not be built")
+	}
+
+	indexPath := filepath.Join(buildDir, "index.html")
+	data, err := os.ReadFile(indexPath)
+	if err != nil {
+		t.Fatalf("index page not found: %v", err)
+	}
+	if strings.Contains(string(data), "Private Note") {
+		t.Error("index page should not list private note")
+	}
+}
+```
+
+- [ ] **Step 4.4: Migrate TestBuildNoteLinkResolution**
+
+Replace `internal/build/build_test.go:248-288` with:
+
+```go
+func TestBuildNoteLinkResolution(t *testing.T) {
+	buildDir := t.TempDir()
+	assetsDir := t.TempDir()
+
+	store := note.NewMemStore()
+	if _, err := store.Put(note.Entry{
+		ID: 3961,
+		Meta: note.Meta{
+			Title:     "First Note",
+			Slug:      "first-note",
+			Tags:      []string{"test"},
+			Public:    true,
+			CreatedAt: time.Date(2023, 1, 30, 0, 0, 0, 0, time.UTC),
+		},
+		Body: "See [second note](3962).\n",
+	}); err != nil {
+		t.Fatalf("store.Put (first): %v", err)
+	}
+	if _, err := store.Put(note.Entry{
+		ID: 3962,
+		Meta: note.Meta{
+			Title:     "Second Note",
+			Slug:      "second-note",
+			Tags:      []string{"test"},
+			Public:    true,
+			CreatedAt: time.Date(2023, 1, 31, 0, 0, 0, 0, time.UTC),
+		},
+		Body: "Hello from second note.\n",
+	}); err != nil {
+		t.Fatalf("store.Put (second): %v", err)
+	}
+
+	cfg := testConfig(t, buildDir, assetsDir)
+	templateFS := os.DirFS("../../")
+	styleCSS := []byte("/* test */")
+	if err := Build(store, cfg, templateFS, styleCSS); err != nil {
+		t.Fatalf("Build() error: %v", err)
+	}
+
+	notePath := filepath.Join(buildDir, "20230130_3961", "first-note", "index.html")
+	data, err := os.ReadFile(notePath)
+	if err != nil {
+		t.Fatalf("note page not found: %v", err)
+	}
+	if !strings.Contains(string(data), `href="/20230131_3962/second-note"`) {
+		t.Errorf("expected resolved note link, got: %s", data)
+	}
+}
+```
+
+- [ ] **Step 4.5: Run the build tests**
+
+```bash
+go test ./internal/build/ -v
+```
+
+Expected: all five tests pass — `TestCleanBuildDir`, `TestCleanBuildDirNonExistent`, `TestCleanBuildDirRejectsRoot`, `TestCopyStaticFiles`, `TestCleanBuildDirRejectsHome`, `TestBuildPublicNote`, `TestBuildSkipsPrivateNote`, `TestBuildNoteLinkResolution`.
+
+**Watch for:** `TestBuildSkipsPrivateNote` expects a path containing `"private-note"` (slugified from `"Private Note"`). The old test used `"private"` because the filename slug was `"private"`. Adjust if your implementation produces a different slug — the slug comes from `chooseSlug` → `slugify(Meta.Title)` → `"private-note"`.
+
+- [ ] **Step 4.6: Run the full suite**
+
+```bash
+go test ./...
+```
+
+Expected: everything green.
+
+- [ ] **Step 4.7: Commit**
+
+```bash
+git add internal/build/build_test.go
+git commit -m "build: migrate tests to note.MemStore"
+```
+
+---
+
+## Task 5: Verification
+
+**Files:** none modified; manual and programmatic checks only.
+
+- [ ] **Step 5.1: Full build**
+
+```bash
+go build ./...
+go test ./...
+```
+
+Expected: both succeed with no output on build; all tests pass.
+
+- [ ] **Step 5.2: Vet**
+
+```bash
+go vet ./...
+```
+
+Expected: no output. Any findings must be fixed before continuing.
+
+- [ ] **Step 5.3: Confirm obsolete helpers are fully gone**
+
+```bash
+grep -n -E "parseDate|trimQuotes|trimQuotesList|cleanTitle|parsedNote|note\.Scan|note\.ParseFrontmatterFields|note\.StripFrontmatter" internal/build/build.go internal/build/build_test.go cmd/notespub/main.go
+```
+
+Expected: no matches. Any match means a leftover reference — remove it before finishing.
+
+- [ ] **Step 5.4: Confirm the Store-path replacements are in place**
+
+```bash
+grep -n -E "store\.All|note\.NewOSStore|note\.NewMemStore|note\.WithPublic|note\.Entry|note\.Store" internal/build/build.go internal/build/build_test.go cmd/notespub/main.go
+```
+
+Expected at least:
+
+- `build.go`: one `store.All(note.WithPublic(true))`, function signature mentions `note.Store`, `note.Entry` appears in `buildNotePages`.
+- `build_test.go`: three `note.NewMemStore()` calls, several `note.Entry{...}` literals.
+- `main.go`: one `note.NewOSStore(cfg.NotesPath)`.
+
+- [ ] **Step 5.5: Manual smoke test against a real notes directory (if available)**
+
+If the operator has a populated notes directory locally, run:
+
+```bash
+go run ./cmd/notespub build --notes ~/notes --out /tmp/notespub-smoke --url https://example.com --site-name "Smoke" --author "Smoke"
+```
+
+Expected: `build complete` logged, `/tmp/notespub-smoke/` contains `index.html`, `feed.xml`, at least one `YYYYMMDD_ID/slug/index.html`, and `tags/…` directories.
+
+Compare the diff of a pre-swap build (from `main`) against the post-swap build of the same notes tree — there should be no meaningful content diff except possibly:
+
+- Tags may now include body `#hashtag` tokens (OSStore merges them into `Meta.Tags`). This is the known behavior change called out in the spec — document it in the PR description if any notes rely on it.
+
+If the operator does not have a populated notes directory, skip this step; the MemStore tests already exercise the full render pipeline.
+
+- [ ] **Step 5.6: Commit anything left (there shouldn't be)**
+
+```bash
+git status
+```
+
+Expected: `nothing to commit, working tree clean`. If anything is uncommitted, it is a missed edit from a prior task — stage and commit it with a descriptive message.
+
+---
+
+## Self-review summary
+
+**Spec coverage:**
+
+| Spec section | Plan task |
+|---|---|
+| Dependency bump to v0.3.20 | Task 1 |
+| Read path via `store.All(note.WithPublic(true))` | Task 3 |
+| `buildNotePages` + `chooseSlug` + `titleOrUID` extraction | Task 3 |
+| Delete `parseDate`, `trimQuotes`, `trimQuotesList`, `cleanTitle`, `parsedNote` | Task 3 + Task 5.3 verification |
+| `Build(store note.Store, cfg, ...)` signature | Task 3 |
+| CLI wiring via `note.NewOSStore` | Task 3 |
+| `render.Render` signature: `string` body + `map[int]string` index | Task 2 |
+| Build tests migrate to `note.MemStore` | Task 4 |
+| Sort order still explicit in `Build` (defensive) | Task 3 (step 3.2, "4. Sort pages newest first") |
+| Error wrapper message changed to `"reading notes: %w"` | Task 3 (step 3.2) |
+| Hashtag tag-merging behavior change documented | Task 5.5 |
+
+All spec items map to tasks. No placeholders, all code blocks complete, all file paths absolute or repo-relative.

--- a/docs/superpowers/plans/2026-04-24-notes-cli-store-refactor.md
+++ b/docs/superpowers/plans/2026-04-24-notes-cli-store-refactor.md
@@ -497,7 +497,7 @@ func buildNotePages(entries []note.Entry, siteRootURL string) ([]page.NotePage, 
 	index := make(map[int]string, len(entries))
 	for _, e := range entries {
 		uid := e.Meta.CreatedAt.Format("20060102") + "_" + strconv.Itoa(e.ID)
-		slug := chooseSlug(e, uid)
+		slug := chooseSlug(e)
 		np := page.NotePage{
 			UID:         uid,
 			ShortUID:    strconv.Itoa(e.ID),
@@ -516,7 +516,7 @@ func buildNotePages(entries []note.Entry, siteRootURL string) ([]page.NotePage, 
 
 // chooseSlug returns the slug to use for e, falling back from Meta.Slug to
 // slugified Meta.Title to the entry's ID.
-func chooseSlug(e note.Entry, uid string) string {
+func chooseSlug(e note.Entry) string {
 	if s := slugify(e.Meta.Slug); s != "" {
 		return s
 	}

--- a/docs/superpowers/specs/2026-04-24-notes-cli-store-refactor-design.md
+++ b/docs/superpowers/specs/2026-04-24-notes-cli-store-refactor-design.md
@@ -1,0 +1,228 @@
+# notes-pub: adopt notes-cli Store interface
+
+**Date:** 2026-04-24
+**Status:** Approved — ready for implementation planning
+
+## Goal
+
+Replace notes-pub's direct use of the `note.Scan` / `note.ParseFrontmatterFields` / `note.StripFrontmatter` free functions from notes-cli v0.1.66 with the new `note.Store` interface (available in notes-cli v0.3.20 and later). The Store is passed into `Build` as an explicit dependency, and build tests migrate to `note.MemStore` so they no longer need filesystem fixtures.
+
+## Non-goals
+
+- No changes to templates, routing, rendered output, image cache, or CLI flags.
+- No new features.
+- No refactoring of `render`, `page`, `images`, or `config` packages beyond what the Store swap directly requires.
+- No new abstraction layer inside notes-pub. The notes-cli `Store` interface is used directly; notes-pub does not define its own wrapper interface.
+
+## Dependency bump
+
+- `go.mod`: `github.com/dreikanter/notes-cli v0.1.66` → `v0.3.20`.
+- `go mod tidy` pulls in `golang.org/x/sync` as a new transitive dependency (used by `OSStore.readConcurrent`). `gopkg.in/yaml.v3` is already present.
+
+## Architecture
+
+```
+cmd/notespub/main.go
+   │  store := note.NewOSStore(cfg.NotesPath)
+   │  build.Build(store, cfg, templateFS, styleCSS)
+   ▼
+internal/build/Build(store note.Store, cfg, templateFS, styleCSS)
+   │
+   ├─ cleanBuildDir / copyStaticFiles            (unchanged)
+   │
+   ├─ entries := store.All(note.WithPublic(true))
+   │
+   ├─ pages, noteIndex := buildNotePages(entries, cfg.SiteRootURL)   ← new helper
+   │
+   ├─ render bodies + attachments into pages     (adapted from step 4)
+   │
+   └─ sort / write note pages / index / tag pages / feed / redirects (unchanged)
+```
+
+The `Store` interface is passed in by the caller. `Build` never touches `cfg.NotesPath` directly anymore; only the caller-constructed store does. Tests substitute `note.MemStore`.
+
+## Read path — the Store seam
+
+**Before** (`internal/build/build.go:180–204`):
+
+```go
+notes, err := note.Scan(cfg.NotesPath)
+// ...
+for _, n := range notes {
+    data, err := os.ReadFile(filepath.Join(cfg.NotesPath, n.RelPath))
+    // ...
+    fm := note.ParseFrontmatterFields(data)
+    if !fm.Public { continue }
+    body := note.StripFrontmatter(data)
+    publicNotes = append(publicNotes, parsedNote{note: n, fm: fm, body: body})
+}
+```
+
+**After:**
+
+```go
+entries, err := store.All(note.WithPublic(true))
+if err != nil {
+    return fmt.Errorf("reading notes: %w", err)
+}
+```
+
+The manual `os.ReadFile` loop and the intermediate `parsedNote` struct disappear. Each `note.Entry` carries `ID int`, `Meta` (with `Title`, `Slug`, `Tags`, `Description`, `Public`, `CreatedAt`, `Type`, `Extra`), and `Body string` already populated. `store.All` returns them newest-first by `Meta.CreatedAt`, which matches the existing `page.SortNotePages` step (which can then be reassessed — see "Sort" below).
+
+## UID / date / ID handling
+
+Current `build.go` stringifies dates and IDs from parsed filename parts:
+
+```go
+uid := pn.note.Date + "_" + pn.note.ID          // note.Note fields are both strings
+// ...
+PublishedAt: parseDate(pn.note.Date),           // custom YYYYMMDD parser
+```
+
+After the swap:
+
+- `entry.ID` is `int`. `ShortUID` becomes `strconv.Itoa(entry.ID)`.
+- `entry.Meta.CreatedAt` is a fully-parsed `time.Time` from the YAML `date` field.
+- `UID` becomes `entry.Meta.CreatedAt.Format("20060102") + "_" + strconv.Itoa(entry.ID)`.
+- `PublishedAt` is `entry.Meta.CreatedAt` directly.
+
+Deleted from `build.go`:
+
+- `parseDate()` (custom `"20060102"` parser)
+- `trimQuotes()` and `trimQuotesList()` (worked around the v0.1.66 hand-rolled YAML parser; v0.3.20 uses `yaml.v3` and returns unquoted strings)
+- `cleanTitle()` (replaced by `titleOrUID`; the quote-stripping it did is no longer needed)
+- `parsedNote` struct
+
+## Page-model extraction
+
+New unexported helper in `internal/build/build.go`:
+
+```go
+func buildNotePages(entries []note.Entry, siteRootURL string) ([]page.NotePage, map[int]string) {
+    pages := make([]page.NotePage, 0, len(entries))
+    index := make(map[int]string, len(entries))
+    for _, e := range entries {
+        slug := chooseSlug(e)   // Meta.Slug → slugified Meta.Title → strconv.Itoa(e.ID)
+        uid := e.Meta.CreatedAt.Format("20060102") + "_" + strconv.Itoa(e.ID)
+        np := page.NotePage{
+            UID:         uid,
+            ShortUID:    strconv.Itoa(e.ID),
+            Slug:        slug,
+            Title:       titleOrUID(e.Meta.Title, uid),
+            Description: e.Meta.Description,
+            Tags:        e.Meta.Tags,
+            SiteRootURL: siteRootURL,
+            PublishedAt: e.Meta.CreatedAt,
+        }
+        index[e.ID] = np.PublicPath()
+        pages = append(pages, np)
+    }
+    return pages, index
+}
+```
+
+Two small unexported helpers encapsulate fallback chains currently inline in `Build`:
+
+- `chooseSlug(e note.Entry) string` — returns `slugify(e.Meta.Slug)`, falling back to `slugify(e.Meta.Title)`, falling back to `strconv.Itoa(e.ID)`.
+- `titleOrUID(title, uid string) string` — returns `title` if non-empty, otherwise `uid`. Replaces the current `cleanTitle` helper (the quote-stripping it did is no longer needed; `yaml.v3` returns unquoted strings).
+
+Rendering (`render.Render` loop) stays in `Build` because it needs `imgCache` and mutates `pages[i].Body` / `pages[i].Attachments` — pulling it out adds no clarity for this refactor.
+
+## Render.Render signature change
+
+`internal/render/render.go`:
+
+- `body []byte` → `body string` (matches `Entry.Body`).
+- `noteIndex map[string]string` → `noteIndex map[int]string` (IDs are `int` now).
+
+Inside `render.Render`, markdown link targets like `[see](3962)` are parsed strings; convert with `strconv.Atoi` at lookup. Non-numeric targets fall through to unchanged behavior. Existing `render_test.go` cases need their `noteIndex` map keys updated from `"3962"` → `3962`.
+
+Image processing callback stays in notes-pub — it is a publishing concern, not a storage concern, and does not belong upstream in notes-cli.
+
+## Sort order
+
+`store.All` returns entries newest-first (for OSStore: by filename `date DESC, id DESC`; for MemStore: by `Meta.CreatedAt` DESC). notes-pub's current `page.SortNotePages(notePages)` after rendering sorts by `PublishedAt` DESC — same order, so the explicit sort becomes redundant. **Keep the explicit sort** anyway: it is cheap, defensive, and makes the order guarantee local to `Build` rather than relying on the Store implementation's ordering.
+
+## CLI wiring
+
+`cmd/notespub/main.go`: construct the store before calling `Build`:
+
+```go
+store := note.NewOSStore(cfg.NotesPath)
+if err := build.Build(store, cfg, templateFS, styleCSS); err != nil {
+    // ...
+}
+```
+
+`cfg.NotesPath` remains in the config struct (loaded from YAML and CLI flags) — only its direct use inside `Build` goes away.
+
+## Tests
+
+### `internal/build/build_test.go`
+
+Migrate the three note-building tests to `note.MemStore`:
+
+- `TestBuildPublicNote`
+- `TestBuildSkipsPrivateNote`
+- `TestBuildNoteLinkResolution`
+
+Each test:
+
+```go
+store := note.NewMemStore()
+_, err := store.Put(note.Entry{
+    ID: 3961,
+    Meta: note.Meta{
+        Title:     "My Test Note",
+        Slug:      "my-test-note",
+        Tags:      []string{"golang", "testing"},
+        Public:    true,
+        CreatedAt: time.Date(2023, 1, 30, 0, 0, 0, 0, time.UTC),
+    },
+    Body: "Hello **world**.\n",
+})
+// ...
+Build(store, cfg, templateFS, styleCSS)
+```
+
+`writeTestNote` helper, `notesDir`, and all markdown-with-YAML literal strings are removed from these tests. `testConfig` no longer needs a `notesPath` argument.
+
+`TestCleanBuildDir*` and `TestCopyStaticFiles` stay unchanged — they test filesystem helpers, not the Store seam.
+
+### Other tests
+
+`internal/config/`, `internal/page/`, `internal/render/`, `internal/images/` tests: only `render_test.go` changes (see "Render.Render signature change" above). The rest are untouched.
+
+## Error handling
+
+No new error paths. The existing wrapper `fmt.Errorf("scanning notes: %w", err)` is renamed to `"reading notes: %w"` to match the new semantics (it's a Store call, not a filesystem scan).
+
+`store.All` errors surface via `%w`. `store.Put` / `store.Get` / `store.Delete` are not used by notes-pub — it is read-only.
+
+## Migration order (single PR)
+
+1. Bump `go.mod` to `notes-cli v0.3.20`; run `go mod tidy`.
+2. Update `render.Render` signature (`[]byte` → `string`, `map[string]string` → `map[int]string`); update `render_test.go` map keys.
+3. In `internal/build/build.go`:
+   - Replace the scan-and-parse loop with `store.All(note.WithPublic(true))`.
+   - Extract `buildNotePages` + `chooseSlug` + `titleOrUID` helpers.
+   - Delete `parseDate`, `trimQuotes`, `trimQuotesList`, `parsedNote`.
+4. Change `Build` signature to `Build(store note.Store, cfg config.Config, templateFS fs.FS, styleCSS []byte) error`.
+5. Update `cmd/notespub/main.go` to construct `note.NewOSStore(cfg.NotesPath)` and pass it in.
+6. Migrate the three Build tests to `MemStore`.
+7. `go test ./...` + manual `notespub build` against a real notes directory as a smoke test.
+
+## Risks
+
+**Frontmatter parity.** notes-cli v0.1.66 used a hand-rolled parser; v0.3.20's `OSStore` uses `yaml.v3`. Any edge case the hand-rolled parser tolerated (unusual whitespace, missing delimiters, etc.) may now error or parse differently. Mitigation: manual build against a real notes directory after the swap, diff the output tree against a pre-swap build.
+
+**`Entry.Body` is `string`, render path currently takes `[]byte`.** Trivial cast at the `render.Render` boundary; no real risk.
+
+**Hashtag tag merging.** `OSStore` merges frontmatter `tags` with body `#hashtag` tokens into `Meta.Tags`. notes-pub's current behavior only reads frontmatter tags. This is a behavior change for any note that uses body hashtags. Mitigation: note in PR description; verify on a real build whether existing notes depend on this being absent. If it is a problem, add an explicit filter in `buildNotePages` that keeps only frontmatter-source tags — but this requires a notes-cli API to distinguish them, which does not currently exist, so accept the behavior change for now and reconsider if it causes real-world issues.
+
+## Out of scope — revisit later
+
+- Further decomposition of `Build` (separate rendering and writing units).
+- A notes-pub-local interface wrapping `note.Store` for finer-grained testability.
+- Parallel rendering (OSStore is already parallel on reads; rendering remains sequential).
+- Moving image processing into notes-cli (rejected: publishing concern, not storage concern).

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/alecthomas/chroma/v2 v2.23.1
-	github.com/dreikanter/notes-cli v0.1.66
+	github.com/dreikanter/notes-cli v0.3.20
 	github.com/spf13/cobra v1.10.2
 	github.com/yuin/goldmark v1.8.2
 	github.com/yuin/goldmark-highlighting/v2 v2.0.0-20230729083705-37449abec8cc
@@ -15,4 +15,5 @@ require (
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
+	golang.org/x/sync v0.20.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/dlclark/regexp2 v1.4.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55k
 github.com/dlclark/regexp2 v1.7.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/dreikanter/notes-cli v0.1.66 h1:5JKRKxavRbbJV6GgEqahhqAFqtHUtIUkM8uT9oqzjgY=
-github.com/dreikanter/notes-cli v0.1.66/go.mod h1:uTsoxcmP94pnbv3yHN4WyRREWGftQRc1fP9Cytp+My4=
+github.com/dreikanter/notes-cli v0.3.20 h1:J0PoVUkGJQwdaHB92UUgHZsz7OSJcdkgpr+pCpwqgp4=
+github.com/dreikanter/notes-cli v0.3.20/go.mod h1:e7yG3AnVo44OSkVx5xHZrIoj6k9wOQ4yIVwrcPExlRw=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
@@ -33,6 +33,8 @@ github.com/yuin/goldmark v1.8.2/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc
 github.com/yuin/goldmark-highlighting/v2 v2.0.0-20230729083705-37449abec8cc h1:+IAOyRda+RLrxa1WC7umKOZRsGq4QrFFMYApOeHzQwQ=
 github.com/yuin/goldmark-highlighting/v2 v2.0.0-20230729083705-37449abec8cc/go.mod h1:ovIvrum6DQJA4QsJSovrkC4saKHQVs7TvcaeO8AIl5I=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -357,7 +357,7 @@ func buildNotePages(entries []note.Entry, siteRootURL string) ([]page.NotePage, 
 	index := make(map[int]string, len(entries))
 	for _, e := range entries {
 		uid := e.Meta.CreatedAt.Format("20060102") + "_" + strconv.Itoa(e.ID)
-		slug := chooseSlug(e, uid)
+		slug := chooseSlug(e)
 		np := page.NotePage{
 			UID:         uid,
 			ShortUID:    strconv.Itoa(e.ID),
@@ -376,7 +376,7 @@ func buildNotePages(entries []note.Entry, siteRootURL string) ([]page.NotePage, 
 
 // chooseSlug returns the slug to use for e, falling back from Meta.Slug to
 // slugified Meta.Title to the entry's ID.
-func chooseSlug(e note.Entry, uid string) string {
+func chooseSlug(e note.Entry) string {
 	if s := slugify(e.Meta.Slug); s != "" {
 		return s
 	}
@@ -467,5 +467,3 @@ func slugify(s string) string {
 	s = strings.Trim(s, "-")
 	return s
 }
-
-

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -163,7 +164,7 @@ func copyStaticFiles(staticPath, buildPath string) error {
 }
 
 // Build generates the static site from notes.
-func Build(cfg config.Config, templateFS fs.FS, styleCSS []byte) error {
+func Build(store note.Store, cfg config.Config, templateFS fs.FS, styleCSS []byte) error {
 	// 0. Clean build directory.
 	if err := cleanBuildDir(cfg.BuildPath); err != nil {
 		return err
@@ -176,64 +177,18 @@ func Build(cfg config.Config, templateFS fs.FS, styleCSS []byte) error {
 		}
 	}
 
-	// 1. Scan notes.
-	notes, err := note.Scan(cfg.NotesPath)
+	// 1. Read public notes from the store.
+	entries, err := store.All(note.WithPublic(true))
 	if err != nil {
-		return fmt.Errorf("scanning notes: %w", err)
+		return fmt.Errorf("reading notes: %w", err)
 	}
 
-	// 2. Parse frontmatter and filter to public notes.
-	type parsedNote struct {
-		note note.Note
-		fm   note.FrontmatterFields
-		body []byte
-	}
+	// 2. Build note-page models and the ID → public-path index.
+	notePages, noteIndex := buildNotePages(entries, cfg.SiteRootURL)
 
-	var publicNotes []parsedNote
-	for _, n := range notes {
-		data, err := os.ReadFile(filepath.Join(cfg.NotesPath, n.RelPath))
-		if err != nil {
-			return fmt.Errorf("reading note %s: %w", n.RelPath, err)
-		}
-		fm := note.ParseFrontmatterFields(data)
-		if !fm.Public {
-			continue
-		}
-		body := note.StripFrontmatter(data)
-		publicNotes = append(publicNotes, parsedNote{note: n, fm: fm, body: body})
-	}
-
-	// 3. Build note pages and note index (for link resolution).
-	noteIndex := make(map[string]string) // note ID -> public path
-	var notePages []page.NotePage
+	// 3. Render Markdown for each note (now that noteIndex is complete).
 	imgCache := images.NewCache(cfg.AssetsPath)
-
-	for _, pn := range publicNotes {
-		uid := pn.note.Date + "_" + pn.note.ID
-		slug := slugify(trimQuotes(pn.fm.Slug))
-		if slug == "" {
-			slug = slugify(trimQuotes(pn.fm.Title))
-		}
-		if slug == "" {
-			slug = pn.note.ID
-		}
-
-		np := page.NotePage{
-			UID:         uid,
-			ShortUID:    pn.note.ID,
-			Slug:        slug,
-			Title:       cleanTitle(trimQuotes(pn.fm.Title), uid),
-			Description: trimQuotes(pn.fm.Description),
-			Tags:        trimQuotesList(pn.fm.Tags),
-			SiteRootURL: cfg.SiteRootURL,
-			PublishedAt: parseDate(pn.note.Date),
-		}
-		noteIndex[pn.note.ID] = np.PublicPath()
-		notePages = append(notePages, np)
-	}
-
-	// 4. Render Markdown for each note (now that noteIndex is complete).
-	for i, pn := range publicNotes {
+	for i, e := range entries {
 		uid := notePages[i].UID
 		processImage := func(src string) (string, error) {
 			entry, err := imgCache.Get(src, uid)
@@ -246,17 +201,17 @@ func Build(cfg config.Config, templateFS fs.FS, styleCSS []byte) error {
 			})
 			return entry.FileName, nil
 		}
-		rendered, err := render.Render(pn.body, noteIndex, processImage)
+		rendered, err := render.Render(e.Body, noteIndex, processImage)
 		if err != nil {
-			return fmt.Errorf("rendering note %s: %w", pn.note.RelPath, err)
+			return fmt.Errorf("rendering note %d: %w", e.ID, err)
 		}
 		notePages[i].Body = string(rendered)
 	}
 
-	// 5. Sort pages newest first.
+	// 4. Sort pages newest first (defensive — store already returns newest-first).
 	page.SortNotePages(notePages)
 
-	// 6. Load templates.
+	// 5. Load templates.
 	tmpl, err := template.New("").ParseFS(templateFS, "templates/*.html")
 	if err != nil {
 		return fmt.Errorf("parsing HTML templates: %w", err)
@@ -282,7 +237,7 @@ func Build(cfg config.Config, templateFS fs.FS, styleCSS []byte) error {
 		HighlightCSS: template.CSS(render.HighlightCSS()),
 	}
 
-	// 7. Write note pages and redirects.
+	// 6. Write note pages and redirects.
 	for _, np := range notePages {
 		nvd := toNoteViewData(np)
 
@@ -326,7 +281,7 @@ func Build(cfg config.Config, templateFS fs.FS, styleCSS []byte) error {
 		}
 	}
 
-	// 8. Write index page.
+	// 7. Write index page.
 	allTags := page.AllTags(notePages)
 	var noteViews []noteViewData
 	for _, np := range notePages {
@@ -345,7 +300,7 @@ func Build(cfg config.Config, templateFS fs.FS, styleCSS []byte) error {
 		return fmt.Errorf("writing index page: %w", err)
 	}
 
-	// 9. Write tag pages.
+	// 8. Write tag pages.
 	for _, tag := range allTags {
 		tagged := page.TaggedPages(notePages, tag)
 		var taggedViews []noteViewData
@@ -368,7 +323,7 @@ func Build(cfg config.Config, templateFS fs.FS, styleCSS []byte) error {
 		}
 	}
 
-	// 10. Write feed.
+	// 9. Write feed.
 	var feedNotes []feedNoteData
 	for _, np := range notePages {
 		feedNotes = append(feedNotes, feedNoteData{
@@ -393,6 +348,50 @@ func Build(cfg config.Config, templateFS fs.FS, styleCSS []byte) error {
 	}
 
 	return nil
+}
+
+// buildNotePages converts note.Entry values into page.NotePage models and
+// builds the ID → public-path index used for link resolution.
+func buildNotePages(entries []note.Entry, siteRootURL string) ([]page.NotePage, map[int]string) {
+	pages := make([]page.NotePage, 0, len(entries))
+	index := make(map[int]string, len(entries))
+	for _, e := range entries {
+		uid := e.Meta.CreatedAt.Format("20060102") + "_" + strconv.Itoa(e.ID)
+		slug := chooseSlug(e, uid)
+		np := page.NotePage{
+			UID:         uid,
+			ShortUID:    strconv.Itoa(e.ID),
+			Slug:        slug,
+			Title:       titleOrUID(e.Meta.Title, uid),
+			Description: e.Meta.Description,
+			Tags:        e.Meta.Tags,
+			SiteRootURL: siteRootURL,
+			PublishedAt: e.Meta.CreatedAt,
+		}
+		index[e.ID] = np.PublicPath()
+		pages = append(pages, np)
+	}
+	return pages, index
+}
+
+// chooseSlug returns the slug to use for e, falling back from Meta.Slug to
+// slugified Meta.Title to the entry's ID.
+func chooseSlug(e note.Entry, uid string) string {
+	if s := slugify(e.Meta.Slug); s != "" {
+		return s
+	}
+	if s := slugify(e.Meta.Title); s != "" {
+		return s
+	}
+	return strconv.Itoa(e.ID)
+}
+
+// titleOrUID returns title when non-empty, otherwise uid as a fallback.
+func titleOrUID(title, uid string) string {
+	if title == "" {
+		return uid
+	}
+	return title
 }
 
 func toNoteViewData(np page.NotePage) noteViewData {
@@ -469,37 +468,4 @@ func slugify(s string) string {
 	return s
 }
 
-func cleanTitle(title, fallback string) string {
-	t := strings.ReplaceAll(title, "`", "")
-	t = strings.Trim(t, `"`)
-	if t == "" {
-		return fallback
-	}
-	return t
-}
 
-// trimQuotes removes surrounding double quotes from a YAML value.
-// The notescli hand-rolled parser doesn't strip YAML string quotes.
-func trimQuotes(s string) string {
-	return strings.Trim(s, `"`)
-}
-
-// trimQuotesList removes surrounding double quotes from each value in a list.
-func trimQuotesList(vals []string) []string {
-	result := make([]string, len(vals))
-	for i, v := range vals {
-		result[i] = trimQuotes(v)
-	}
-	return result
-}
-
-func parseDate(dateStr string) time.Time {
-	if len(dateStr) < 8 {
-		return time.Time{}
-	}
-	t, err := time.Parse("20060102", dateStr[:8])
-	if err != nil {
-		return time.Time{}
-	}
-	return t
-}

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -292,3 +292,53 @@ func TestBuildNoteLinkResolution(t *testing.T) {
 		t.Errorf("expected resolved note link, got: %s", data)
 	}
 }
+
+func TestChooseSlug(t *testing.T) {
+	tests := []struct {
+		name  string
+		entry note.Entry
+		want  string
+	}{
+		{
+			name:  "explicit slug wins",
+			entry: note.Entry{ID: 42, Meta: note.Meta{Slug: "explicit-slug", Title: "Some Title"}},
+			want:  "explicit-slug",
+		},
+		{
+			name:  "title fallback when slug empty",
+			entry: note.Entry{ID: 42, Meta: note.Meta{Title: "Some Title"}},
+			want:  "some-title",
+		},
+		{
+			name:  "ID fallback when slug and title both empty",
+			entry: note.Entry{ID: 42},
+			want:  "42",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := chooseSlug(tt.entry); got != tt.want {
+				t.Errorf("chooseSlug() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTitleOrUID(t *testing.T) {
+	tests := []struct {
+		name  string
+		title string
+		uid   string
+		want  string
+	}{
+		{name: "non-empty title wins", title: "Hello", uid: "20230130_42", want: "Hello"},
+		{name: "empty title falls back to uid", title: "", uid: "20230130_42", want: "20230130_42"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := titleOrUID(tt.title, tt.uid); got != tt.want {
+				t.Errorf("titleOrUID(%q, %q) = %q, want %q", tt.title, tt.uid, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -5,7 +5,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/dreikanter/notes-cli/note"
 	"github.com/dreikanter/notes-pub/internal/config"
 )
 
@@ -96,21 +98,9 @@ func TestCleanBuildDirRejectsHome(t *testing.T) {
 	}
 }
 
-func writeTestNote(t *testing.T, root, relPath, content string) {
-	t.Helper()
-	full := filepath.Join(root, relPath)
-	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func testConfig(t *testing.T, notesPath, buildPath, assetsPath string) config.Config {
+func testConfig(t *testing.T, buildPath, assetsPath string) config.Config {
 	t.Helper()
 	return config.Config{
-		NotesPath:   notesPath,
 		AssetsPath:  assetsPath,
 		BuildPath:   buildPath,
 		SiteRootURL: "https://example.com",
@@ -120,24 +110,28 @@ func testConfig(t *testing.T, notesPath, buildPath, assetsPath string) config.Co
 }
 
 func TestBuildPublicNote(t *testing.T) {
-	notesDir := t.TempDir()
 	buildDir := t.TempDir()
 	assetsDir := t.TempDir()
 
-	writeTestNote(t, notesDir, "2023/01/20230130_3961_my-note.md", `---
-title: My Test Note
-slug: my-test-note
-tags: [golang, testing]
-public: true
----
+	store := note.NewMemStore()
+	if _, err := store.Put(note.Entry{
+		ID: 3961,
+		Meta: note.Meta{
+			Title:     "My Test Note",
+			Slug:      "my-test-note",
+			Tags:      []string{"golang", "testing"},
+			Public:    true,
+			CreatedAt: time.Date(2023, 1, 30, 0, 0, 0, 0, time.UTC),
+		},
+		Body: "Hello **world**.\n",
+	}); err != nil {
+		t.Fatalf("store.Put: %v", err)
+	}
 
-Hello **world**.
-`)
-
-	cfg := testConfig(t, notesDir, buildDir, assetsDir)
+	cfg := testConfig(t, buildDir, assetsDir)
 	templateFS := os.DirFS("../../")
 	styleCSS := []byte("/* test */")
-	if err := Build(cfg, templateFS, styleCSS); err != nil {
+	if err := Build(store, cfg, templateFS, styleCSS); err != nil {
 		t.Fatalf("Build() error: %v", err)
 	}
 
@@ -211,26 +205,31 @@ Hello **world**.
 }
 
 func TestBuildSkipsPrivateNote(t *testing.T) {
-	notesDir := t.TempDir()
 	buildDir := t.TempDir()
 	assetsDir := t.TempDir()
 
-	writeTestNote(t, notesDir, "2023/01/20230130_3961_private.md", `---
-title: Private Note
-tags: [secret]
----
+	store := note.NewMemStore()
+	if _, err := store.Put(note.Entry{
+		ID: 3961,
+		Meta: note.Meta{
+			Title:     "Private Note",
+			Tags:      []string{"secret"},
+			Public:    false,
+			CreatedAt: time.Date(2023, 1, 30, 0, 0, 0, 0, time.UTC),
+		},
+		Body: "This is private.\n",
+	}); err != nil {
+		t.Fatalf("store.Put: %v", err)
+	}
 
-This is private.
-`)
-
-	cfg := testConfig(t, notesDir, buildDir, assetsDir)
+	cfg := testConfig(t, buildDir, assetsDir)
 	templateFS := os.DirFS("../../")
 	styleCSS := []byte("/* test */")
-	if err := Build(cfg, templateFS, styleCSS); err != nil {
+	if err := Build(store, cfg, templateFS, styleCSS); err != nil {
 		t.Fatalf("Build() error: %v", err)
 	}
 
-	notePath := filepath.Join(buildDir, "20230130_3961", "private", "index.html")
+	notePath := filepath.Join(buildDir, "20230130_3961", "private-note", "index.html")
 	if _, err := os.Stat(notePath); err == nil {
 		t.Error("private note should not be built")
 	}
@@ -246,34 +245,41 @@ This is private.
 }
 
 func TestBuildNoteLinkResolution(t *testing.T) {
-	notesDir := t.TempDir()
 	buildDir := t.TempDir()
 	assetsDir := t.TempDir()
 
-	writeTestNote(t, notesDir, "2023/01/20230130_3961_first.md", `---
-title: First Note
-slug: first-note
-tags: [test]
-public: true
----
+	store := note.NewMemStore()
+	if _, err := store.Put(note.Entry{
+		ID: 3961,
+		Meta: note.Meta{
+			Title:     "First Note",
+			Slug:      "first-note",
+			Tags:      []string{"test"},
+			Public:    true,
+			CreatedAt: time.Date(2023, 1, 30, 0, 0, 0, 0, time.UTC),
+		},
+		Body: "See [second note](3962).\n",
+	}); err != nil {
+		t.Fatalf("store.Put (first): %v", err)
+	}
+	if _, err := store.Put(note.Entry{
+		ID: 3962,
+		Meta: note.Meta{
+			Title:     "Second Note",
+			Slug:      "second-note",
+			Tags:      []string{"test"},
+			Public:    true,
+			CreatedAt: time.Date(2023, 1, 31, 0, 0, 0, 0, time.UTC),
+		},
+		Body: "Hello from second note.\n",
+	}); err != nil {
+		t.Fatalf("store.Put (second): %v", err)
+	}
 
-See [second note](3962).
-`)
-
-	writeTestNote(t, notesDir, "2023/01/20230131_3962_second.md", `---
-title: Second Note
-slug: second-note
-tags: [test]
-public: true
----
-
-Hello from second note.
-`)
-
-	cfg := testConfig(t, notesDir, buildDir, assetsDir)
+	cfg := testConfig(t, buildDir, assetsDir)
 	templateFS := os.DirFS("../../")
 	styleCSS := []byte("/* test */")
-	if err := Build(cfg, templateFS, styleCSS); err != nil {
+	if err := Build(store, cfg, templateFS, styleCSS); err != nil {
 		t.Fatalf("Build() error: %v", err)
 	}
 

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -229,9 +229,9 @@ func TestBuildSkipsPrivateNote(t *testing.T) {
 		t.Fatalf("Build() error: %v", err)
 	}
 
-	notePath := filepath.Join(buildDir, "20230130_3961", "private-note", "index.html")
-	if _, err := os.Stat(notePath); err == nil {
-		t.Error("private note should not be built")
+	uidDir := filepath.Join(buildDir, "20230130_3961")
+	if _, err := os.Stat(uidDir); err == nil {
+		t.Error("private note UID directory should not be created")
 	}
 
 	indexPath := filepath.Join(buildDir, "index.html")

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"regexp"
+	"strconv"
 
 	chromahtml "github.com/alecthomas/chroma/v2/formatters/html"
 	"github.com/alecthomas/chroma/v2/styles"
@@ -38,7 +39,7 @@ type ProcessImageFunc func(src string) (localName string, err error)
 // Render converts Markdown to HTML.
 // noteIndex maps note IDs to their public paths (for link resolution).
 // processImage is called for external image URLs (may be nil).
-func Render(source []byte, noteIndex map[string]string, processImage ProcessImageFunc) ([]byte, error) {
+func Render(source string, noteIndex map[int]string, processImage ProcessImageFunc) ([]byte, error) {
 	md := goldmark.New(
 		goldmark.WithExtensions(
 			extension.GFM,
@@ -57,7 +58,8 @@ func Render(source []byte, noteIndex map[string]string, processImage ProcessImag
 		),
 	)
 
-	reader := text.NewReader(source)
+	sourceBytes := []byte(source)
+	reader := text.NewReader(sourceBytes)
 	doc := md.Parser().Parse(reader)
 
 	// Walk AST and transform links and images.
@@ -70,8 +72,11 @@ func Render(source []byte, noteIndex map[string]string, processImage ProcessImag
 		case *ast.Link:
 			dest := string(node.Destination)
 			if isNoteID(dest) && noteIndex != nil {
-				if resolved, ok := noteIndex[dest]; ok {
-					node.Destination = []byte("/" + resolved)
+				id, err := strconv.Atoi(dest)
+				if err == nil {
+					if resolved, ok := noteIndex[id]; ok {
+						node.Destination = []byte("/" + resolved)
+					}
 				}
 			}
 
@@ -93,7 +98,7 @@ func Render(source []byte, noteIndex map[string]string, processImage ProcessImag
 	}
 
 	var buf bytes.Buffer
-	if err := md.Renderer().Render(&buf, source, doc); err != nil {
+	if err := md.Renderer().Render(&buf, sourceBytes, doc); err != nil {
 		return nil, err
 	}
 	return buf.Bytes(), nil

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -7,7 +7,7 @@ import (
 
 func TestRenderBasicMarkdown(t *testing.T) {
 	md := "# Hello\n\nThis is a **test**.\n"
-	html, err := Render([]byte(md), nil, nil)
+	html, err := Render(md, nil, nil)
 	if err != nil {
 		t.Fatalf("Render() error: %v", err)
 	}
@@ -21,7 +21,7 @@ func TestRenderBasicMarkdown(t *testing.T) {
 
 func TestRenderFencedCode(t *testing.T) {
 	md := "```go\nfmt.Println(\"hello\")\n```\n"
-	html, err := Render([]byte(md), nil, nil)
+	html, err := Render(md, nil, nil)
 	if err != nil {
 		t.Fatalf("Render() error: %v", err)
 	}
@@ -31,11 +31,11 @@ func TestRenderFencedCode(t *testing.T) {
 }
 
 func TestRenderNoteLink(t *testing.T) {
-	noteIndex := map[string]string{
-		"8823": "20260106_8823/some-slug",
+	noteIndex := map[int]string{
+		8823: "20260106_8823/some-slug",
 	}
 	md := "See [this note](8823)\n"
-	html, err := Render([]byte(md), noteIndex, nil)
+	html, err := Render(md, noteIndex, nil)
 	if err != nil {
 		t.Fatalf("Render() error: %v", err)
 	}
@@ -46,7 +46,7 @@ func TestRenderNoteLink(t *testing.T) {
 
 func TestRenderNoteLinkUnresolved(t *testing.T) {
 	md := "See [this note](9999)\n"
-	html, err := Render([]byte(md), nil, nil)
+	html, err := Render(md, nil, nil)
 	if err != nil {
 		t.Fatalf("Render() error: %v", err)
 	}
@@ -57,7 +57,7 @@ func TestRenderNoteLinkUnresolved(t *testing.T) {
 
 func TestRenderAutolink(t *testing.T) {
 	md := "Visit https://example.com for info.\n"
-	html, err := Render([]byte(md), nil, nil)
+	html, err := Render(md, nil, nil)
 	if err != nil {
 		t.Fatalf("Render() error: %v", err)
 	}
@@ -68,7 +68,7 @@ func TestRenderAutolink(t *testing.T) {
 
 func TestRenderStrikethrough(t *testing.T) {
 	md := "This is ~~deleted~~ text.\n"
-	html, err := Render([]byte(md), nil, nil)
+	html, err := Render(md, nil, nil)
 	if err != nil {
 		t.Fatalf("Render() error: %v", err)
 	}
@@ -79,7 +79,7 @@ func TestRenderStrikethrough(t *testing.T) {
 
 func TestRenderTable(t *testing.T) {
 	md := "| A | B |\n|---|---|\n| 1 | 2 |\n"
-	html, err := Render([]byte(md), nil, nil)
+	html, err := Render(md, nil, nil)
 	if err != nil {
 		t.Fatalf("Render() error: %v", err)
 	}
@@ -95,7 +95,7 @@ func TestRenderImageCallback(t *testing.T) {
 		return "abc123.jpg", nil
 	}
 	md := "![alt text](https://example.com/img.jpg)\n"
-	html, err := Render([]byte(md), nil, processImage)
+	html, err := Render(md, nil, processImage)
 	if err != nil {
 		t.Fatalf("Render() error: %v", err)
 	}


### PR DESCRIPTION
## Summary

Refactor notes-pub to use the `note.Store` interface introduced in notes-cli v0.3.20 instead of the v0.1.66 free functions (`note.Scan`, `note.ParseFrontmatterFields`, `note.StripFrontmatter`). `Build` now takes a `note.Store` explicitly; build tests use `note.MemStore` instead of writing markdown files to temp directories.

- Dependency bumped `notes-cli` v0.1.66 → v0.3.20
- `Build(store note.Store, cfg, templateFS, styleCSS)` — Store passed in by `cmd/notespub/main.go`
- Read path collapses to a single `store.All(note.WithPublic(true))` call; `parsedNote` struct + `parseDate` / `trimQuotes` / `trimQuotesList` / `cleanTitle` helpers deleted (workarounds for the old hand-rolled YAML parser)
- New `buildNotePages` / `chooseSlug` / `titleOrUID` helpers extract the page-model construction from `Build`
- `render.Render` retyped to take `source string` and `noteIndex map[int]string` (matches `Entry.Body string` and `Entry.ID int`)

Spec: `docs/superpowers/specs/2026-04-24-notes-cli-store-refactor-design.md`
Plan: `docs/superpowers/plans/2026-04-24-notes-cli-store-refactor.md`

### Behavior change to be aware of

notes-cli v0.3.20's `OSStore` merges body `#hashtag` tokens into `Meta.Tags`, so any public note that uses body hashtags will now have those treated as tags in the generated index and tag pages. The old hand-rolled parser only read frontmatter tags. Notes that don't use body hashtags are unaffected.

## Test plan

- [x] `go test ./...` — all 6 packages green (verified locally)
- [x] `go vet ./...` — clean (verified locally)
- [x] Smoke test: run `notespub build` against a real notes directory and diff output against a pre-refactor build; confirm only expected differences (e.g. possible new tags from body hashtags)
- [x] Review the merge against the 3 new main commits (CHANGELOG/workflow/related-styling) — minor overlap in `cmd/notespub/main.go` and `internal/build/build.go` may need manual reconciliation

## References

- [x] Closes #34
- [x] Closes #34