### PR TITLE
Add init command for sample config

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Config file discovery order:
 3. `npub.yml` inside `$NOTES_PATH` (or `--notes` value) if it exists
 4. `npub.yml` in the current directory
 
-See `npub.sample.yml` in the repo for a starting template.
+Run `npub init [path]` to create a commented `npub.yml` sample in a directory. If `path` is omitted, the current directory is used.
 
 The optional `intro` field renders as a paragraph above the posts list on the index page. Leave it empty or unset to omit.
 
@@ -73,6 +73,14 @@ Downloaded images are cached in an assets directory, organized by note UID. By d
 Files in the `static` subdirectory of `notes_path` are copied as-is to the build output root. Use this for `CNAME`, `robots.txt`, `favicon.ico`, etc. Override with `static_path` in the config or `--static` flag.
 
 ## Usage
+
+Create a configuration file:
+
+```sh
+npub init
+# or create a new project directory
+npub init ./my-notes-site
+```
 
 Build the site:
 

--- a/cmd/npub/main.go
+++ b/cmd/npub/main.go
@@ -30,6 +30,24 @@ var rootCmd = &cobra.Command{
 	Short: "Build a static site from a local notes store",
 }
 
+var initCmd = &cobra.Command{
+	Use:   "init [path]",
+	Short: "Create a sample npub configuration",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		path := "."
+		if len(args) > 0 {
+			path = args[0]
+		}
+		cfgPath, err := initConfig(path)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "created %s\nedit it to set required fields before running npub build\n", cfgPath)
+		return nil
+	},
+}
+
 var buildCmd = &cobra.Command{
 	Use:   "build",
 	Short: "Build the static site",
@@ -64,6 +82,44 @@ var serveCmd = &cobra.Command{
 		log.Printf("serving %s on http://localhost%s", dir, addr)
 		return http.ListenAndServe(addr, http.FileServer(http.Dir(dir)))
 	},
+}
+
+func initConfig(path string) (string, error) {
+	path = expandHome(os.ExpandEnv(path))
+	if path == "" {
+		path = "."
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return "", fmt.Errorf("cannot inspect %s: %w", path, err)
+		}
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			return "", fmt.Errorf("cannot create directory %s: %w", path, err)
+		}
+	} else if !info.IsDir() {
+		return "", fmt.Errorf("%s is not a directory", path)
+	}
+
+	cfgPath := filepath.Join(path, config.DefaultConfigFile)
+	file, err := os.OpenFile(cfgPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
+	if err != nil {
+		if os.IsExist(err) {
+			return "", fmt.Errorf("config file already exists: %s", cfgPath)
+		}
+		return "", fmt.Errorf("cannot create config file %s: %w", cfgPath, err)
+	}
+	if _, err := file.Write(npub.SampleConfig); err != nil {
+		_ = file.Close()
+		_ = os.Remove(cfgPath)
+		return "", fmt.Errorf("cannot write config file %s: %w", cfgPath, err)
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(cfgPath)
+		return "", fmt.Errorf("cannot write config file %s: %w", cfgPath, err)
+	}
+	return cfgPath, nil
 }
 
 func resolveConfigPath(flagValue, envValue, notesPath string) string {
@@ -135,6 +191,7 @@ func init() {
 	serveCmd.Flags().String("dir", "./dist", "directory to serve")
 	serveCmd.Flags().String("port", "4000", "port to listen on")
 
+	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(buildCmd)
 	rootCmd.AddCommand(serveCmd)
 }

--- a/cmd/npub/main_test.go
+++ b/cmd/npub/main_test.go
@@ -3,10 +3,94 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/dreikanter/npub/internal/config"
 )
+
+func TestInitConfigCreatesSampleInNewDirectory(t *testing.T) {
+	target := filepath.Join(t.TempDir(), "site")
+
+	cfgPath, err := initConfig(target)
+	if err != nil {
+		t.Fatalf("initConfig() error = %v", err)
+	}
+
+	wantPath := filepath.Join(target, config.DefaultConfigFile)
+	if cfgPath != wantPath {
+		t.Fatalf("initConfig() path = %q, want %q", cfgPath, wantPath)
+	}
+
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	for _, want := range []string{
+		`# notes_path: ""`,
+		`# build_path: "./dist"`,
+		`# license_name: "CC BY 4.0"`,
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("generated config missing %q", want)
+		}
+	}
+}
+
+func TestInitConfigDefaultsToCurrentDirectory(t *testing.T) {
+	dir := t.TempDir()
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(oldWd)
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	cfgPath, err := initConfig(".")
+	if err != nil {
+		t.Fatalf("initConfig() error = %v", err)
+	}
+	if cfgPath != config.DefaultConfigFile {
+		t.Fatalf("initConfig() path = %q", cfgPath)
+	}
+	if _, err := os.Stat(filepath.Join(dir, config.DefaultConfigFile)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestInitConfigDoesNotOverwriteExistingConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, config.DefaultConfigFile)
+	if err := os.WriteFile(cfgPath, []byte("existing"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := initConfig(dir); err == nil {
+		t.Fatal("initConfig() error = nil, want error")
+	}
+
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "existing" {
+		t.Fatalf("existing config overwritten: %q", data)
+	}
+}
+
+func TestInitConfigRejectsNonDirectoryPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(path, []byte("file"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := initConfig(path); err == nil {
+		t.Fatal("initConfig() error = nil, want error")
+	}
+}
 
 func TestResolveConfigPath(t *testing.T) {
 	home, _ := os.UserHomeDir()

--- a/embed.go
+++ b/embed.go
@@ -7,3 +7,6 @@ var TemplateFS embed.FS
 
 //go:embed style.css
 var StyleCSS []byte
+
+//go:embed npub.yml.sample
+var SampleConfig []byte

--- a/npub.sample.yml
+++ b/npub.sample.yml
@@ -1,7 +1,0 @@
----
-notes_path: "~/notes"
-build_path: "./dist"
-site_root_url: "https://example.com"
-site_name: "My Notes"
-author_name: "Ada Lovelace"
-# intro: "Optional short paragraph shown above the posts list on the index page."

--- a/npub.yml.sample
+++ b/npub.yml.sample
@@ -1,0 +1,34 @@
+---
+# npub configuration sample.
+# Uncomment the settings you want to customize.
+
+# Path to your notes store. Defaults to the NOTES_PATH environment variable.
+# notes_path: ""
+
+# Directory for cached image assets. Defaults to <notes_path>/images.
+# assets_path: ""
+
+# Directory where the generated site is written.
+# build_path: "./dist"
+
+# Directory with static files copied to the build output root.
+# Defaults to <notes_path>/static.
+# static_path: ""
+
+# Public root URL of the published site. Required.
+# site_root_url: ""
+
+# Site title shown in pages and feeds. Required.
+# site_name: ""
+
+# Author name shown in pages and feeds. Required.
+# author_name: ""
+
+# License name shown in the footer.
+# license_name: "CC BY 4.0"
+
+# License URL linked from the footer.
+# license_url: "https://creativecommons.org/licenses/by/4.0/"
+
+# Optional short paragraph shown above the posts list on the index page.
+# intro: ""


### PR DESCRIPTION
## Summary

- add `npub init [path]` to create an embedded sample `npub.yml` in the current or target directory
- rename `npub.sample.yml` to `npub.yml.sample`, expand it with commented default settings, and embed it in the binary
- document the init workflow and add tests for config generation

## References

- Closes https://github.com/dreikanter/npub/issues/39