### PR TITLE
Add npub init command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.3.0] - 2026-04-25
+
+### Added
+
+- `npub init [path]` command that scaffolds a starter `npub.yml` in the given directory (default: current directory). The generated file lists every config option set to its default and commented out.
+
+### Changed
+
+- Rename `npub.sample.yml` to `npub.yml.sample` and embed it in the binary; `npub init` writes this template.
+
 ## [0.2.0] - 2026-04-25
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -26,15 +26,14 @@ make build
 
 ## Configuration
 
-Create a `npub.yml` file:
+Generate a starter `npub.yml` in the current directory (or pass a target path):
 
-```yaml
-notes_path: "~/notes"
-build_path: "dist"
-site_root_url: "https://example.com"
-site_name: "My Notes"
-author_name: "Ada Lovelace"
+```sh
+npub init
+npub init path/to/project
 ```
+
+The generated file lists every option set to its default and commented out — uncomment and edit what you need. Required fields are `site_root_url`, `site_name`, and `author_name`.
 
 All values can be overridden with CLI flags:
 
@@ -60,7 +59,7 @@ Config file discovery order:
 3. `npub.yml` inside `$NOTES_PATH` (or `--notes` value) if it exists
 4. `npub.yml` in the current directory
 
-See `npub.sample.yml` in the repo for a starting template.
+See `npub.yml.sample` in the repo for the same starting template.
 
 The optional `intro` field renders as a paragraph above the posts list on the index page. Leave it empty or unset to omit.
 

--- a/cmd/npub/init.go
+++ b/cmd/npub/init.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/dreikanter/npub"
+	"github.com/dreikanter/npub/internal/config"
+	"github.com/spf13/cobra"
+)
+
+var initCmd = &cobra.Command{
+	Use:   "init [path]",
+	Short: "Create a sample npub.yml in the given directory (default: current directory)",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dir := "."
+		if len(args) > 0 {
+			dir = args[0]
+		}
+		dir = expandHome(os.ExpandEnv(dir))
+
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("create directory: %w", err)
+		}
+
+		target := filepath.Join(dir, config.DefaultConfigFile)
+		if _, err := os.Stat(target); err == nil {
+			return fmt.Errorf("%s already exists", target)
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("check %s: %w", target, err)
+		}
+
+		if err := os.WriteFile(target, npub.SampleConfig, 0o644); err != nil {
+			return fmt.Errorf("write config: %w", err)
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "Created %s\n", target)
+		return nil
+	},
+}

--- a/cmd/npub/init_test.go
+++ b/cmd/npub/init_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dreikanter/npub"
+	"github.com/dreikanter/npub/internal/config"
+)
+
+func runInit(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	rootCmd.SetArgs(append([]string{"init"}, args...))
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+	})
+	err := rootCmd.Execute()
+	return out.String(), err
+}
+
+func TestInitCommandWritesSampleConfig(t *testing.T) {
+	dir := t.TempDir()
+
+	out, err := runInit(t, dir)
+	if err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	target := filepath.Join(dir, config.DefaultConfigFile)
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if !bytes.Equal(got, npub.SampleConfig) {
+		t.Errorf("written config does not match embedded sample")
+	}
+	if !strings.Contains(out, target) {
+		t.Errorf("output %q does not mention target path %q", out, target)
+	}
+}
+
+func TestInitCommandCreatesMissingDirectory(t *testing.T) {
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "new", "project")
+
+	if _, err := runInit(t, dir); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, config.DefaultConfigFile)); err != nil {
+		t.Errorf("expected config file to exist: %v", err)
+	}
+}
+
+func TestInitCommandRefusesToOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, config.DefaultConfigFile)
+	if err := os.WriteFile(target, []byte("existing: true\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := runInit(t, dir); err == nil {
+		t.Fatal("expected error when config already exists, got nil")
+	}
+
+	got, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if string(got) != "existing: true\n" {
+		t.Errorf("existing config was overwritten: got %q", got)
+	}
+}
+
+func TestInitCommandDefaultsToCwd(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	if _, err := runInit(t); err != nil {
+		t.Fatalf("init failed: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, config.DefaultConfigFile)); err != nil {
+		t.Errorf("expected config file in cwd: %v", err)
+	}
+}

--- a/cmd/npub/main.go
+++ b/cmd/npub/main.go
@@ -137,4 +137,5 @@ func init() {
 
 	rootCmd.AddCommand(buildCmd)
 	rootCmd.AddCommand(serveCmd)
+	rootCmd.AddCommand(initCmd)
 }

--- a/embed.go
+++ b/embed.go
@@ -7,3 +7,6 @@ var TemplateFS embed.FS
 
 //go:embed style.css
 var StyleCSS []byte
+
+//go:embed npub.yml.sample
+var SampleConfig []byte

--- a/npub.sample.yml
+++ b/npub.sample.yml
@@ -1,7 +1,0 @@
----
-notes_path: "~/notes"
-build_path: "./dist"
-site_root_url: "https://example.com"
-site_name: "My Notes"
-author_name: "Ada Lovelace"
-# intro: "Optional short paragraph shown above the posts list on the index page."

--- a/npub.yml.sample
+++ b/npub.yml.sample
@@ -1,0 +1,34 @@
+# npub configuration. Uncomment any line below and edit it to override the
+# default. Required fields (site_root_url, site_name, author_name) must be set.
+
+# Path to the notes directory. Falls back to the NOTES_PATH env var.
+# notes_path: "~/notes"
+
+# Path where downloaded image assets are cached.
+# Defaults to <notes_path>/images.
+# assets_path: ""
+
+# Output directory for the built site.
+# build_path: "./dist"
+
+# Files copied as-is to the build root (CNAME, robots.txt, favicon.ico, etc.).
+# Defaults to <notes_path>/static.
+# static_path: ""
+
+# Site root URL (required).
+# site_root_url: "https://example.com"
+
+# Site name shown in headers and feeds (required).
+# site_name: "My Notes"
+
+# Author name shown in metadata and feeds (required).
+# author_name: "Ada Lovelace"
+
+# License name displayed in the footer.
+# license_name: "CC BY 4.0"
+
+# License URL linked from the footer.
+# license_url: "https://creativecommons.org/licenses/by/4.0/"
+
+# Optional paragraph rendered above the posts list on the index page.
+# intro: ""


### PR DESCRIPTION
## Summary

- New `npub init [path]` command scaffolds a starter `npub.yml` from an embedded template; defaults to the current working directory and refuses to overwrite an existing file.
- Renames `npub.sample.yml` to `npub.yml.sample` and embeds it in the binary as the source for `npub init`. The template lists every config option set to its default and commented out, with short explanatory comments.
- Updates README to document `npub init` as the recommended way to create a config.

## Test plan

- [x] `go test ./...`
- [x] `go build ./...`
- [x] Manual: `npub init <tmpdir>` writes the sample, second run errors with "already exists"
- [x] Manual: `npub init` with no args writes to cwd

Closes #39