### PR TITLE
Add GitHub Actions checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,24 @@
+name: lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/actions/checkout
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      # https://github.com/actions/setup-go
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: stable
+
+      # https://github.com/golangci/golangci-lint-action
+      - name: Run linters
+        uses: golangci/golangci-lint-action@v9

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Tag from CHANGELOG

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        go: [stable]
+    runs-on: ${{ matrix.os }}
+    steps:
+      # https://github.com/actions/checkout
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      # https://github.com/actions/setup-go
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ matrix.go }}
+
+      - name: Run tests
+        run: make test

--- a/.github/workflows/vuln.yml
+++ b/.github/workflows/vuln.yml
@@ -1,0 +1,14 @@
+name: vuln
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  vuln:
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/golang/govulncheck-action
+      - name: Run govulncheck
+        uses: golang/govulncheck-action@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.2.1] - 2026-04-26
+
+### Added
+
+- Add `npub init [path]` to generate a sample `npub.yml` configuration.
+- Add GitHub Actions workflows for tests, linting, and vulnerability scanning.
+- Add the embedded nview favicon asset to generated sites.
+
+### Changed
+
+- Switch the notes dependency to `github.com/dreikanter/notesctl`.
+- Refactor tests to use `testify` assertions and shared helpers.
+- Update Go and Tailwind dependencies to the latest stable versions.
+- Update the auto-tag workflow to `actions/checkout@v6`.
+- Pin the local lint command to `golangci-lint` v2.11.4.
+
+### Fixed
+
+- Bump the Go patch version to `1.25.9` to resolve standard-library vulnerability findings.
+- Address lint findings reported by `golangci-lint`.
+
 ## [0.2.0] - 2026-04-25
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -28,4 +28,4 @@ test:
 	go test ./...
 
 lint:
-	go tool golangci-lint run
+	go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 run

--- a/cmd/npub/main.go
+++ b/cmd/npub/main.go
@@ -43,8 +43,8 @@ var initCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "created %s\nedit it to set required fields before running npub build\n", cfgPath)
-		return nil
+		_, err = fmt.Fprintf(cmd.OutOrStdout(), "created %s\nedit it to set required fields before running npub build\n", cfgPath)
+		return err
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dreikanter/npub
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/alecthomas/chroma/v2 v2.23.1

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -156,7 +156,7 @@ func copyStaticFiles(staticPath, buildPath string) error {
 		if err != nil {
 			return err
 		}
-		defer src.Close()
+		defer func() { _ = src.Close() }()
 		if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
 			return err
 		}
@@ -164,7 +164,7 @@ func copyStaticFiles(staticPath, buildPath string) error {
 		if err != nil {
 			return err
 		}
-		defer dst.Close()
+		defer func() { _ = dst.Close() }()
 		_, err = io.Copy(dst, src)
 		return err
 	})

--- a/internal/images/images.go
+++ b/internal/images/images.go
@@ -52,7 +52,9 @@ func (c *Cache) Get(imageURL, pageUID string) (Entry, error) {
 	}
 
 	idx[imageURL] = entry
-	c.saveIndex(idx)
+	if err := c.saveIndex(idx); err != nil {
+		return Entry{}, err
+	}
 	return entry, nil
 }
 
@@ -87,7 +89,9 @@ func (c *Cache) downloadCleanShot(imageURL string) ([]byte, string, error) {
 	if err != nil {
 		return nil, "", err
 	}
-	resp.Body.Close()
+	if err := resp.Body.Close(); err != nil {
+		return nil, "", err
+	}
 
 	if resp.StatusCode < 300 || resp.StatusCode >= 400 {
 		return c.downloadDirect(imageURL)
@@ -114,7 +118,7 @@ func (c *Cache) downloadDirect(imageURL string) ([]byte, string, error) {
 	if err != nil {
 		return nil, "", err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return nil, "", fmt.Errorf("HTTP %d", resp.StatusCode)
 	}
@@ -173,17 +177,19 @@ func (c *Cache) loadIndex() map[string]Entry {
 	return idx
 }
 
-func (c *Cache) saveIndex(idx map[string]Entry) {
+func (c *Cache) saveIndex(idx map[string]Entry) error {
 	data, err := json.MarshalIndent(idx, "", "  ")
 	if err != nil {
-		return
+		return err
 	}
-	os.WriteFile(c.indexPath(), data, 0o644)
+	return os.WriteFile(c.indexPath(), data, 0o644)
 }
 
 func randomName(ext string) string {
 	b := make([]byte, 16)
-	rand.Read(b)
+	if _, err := rand.Read(b); err != nil {
+		panic(err)
+	}
 	return hex.EncodeToString(b) + ext
 }
 

--- a/internal/images/images_test.go
+++ b/internal/images/images_test.go
@@ -59,11 +59,11 @@ func TestCacheMissDownloads(t *testing.T) {
 func TestCleanshotRedirect(t *testing.T) {
 	directURL := ""
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.URL.Path == "/share/abc+":
+		switch r.URL.Path {
+		case "/share/abc+":
 			w.Header().Set("Location", directURL+"/direct/photo.jpg?response-content-disposition=attachment%3Bfilename%3Dscreenshot.png")
 			w.WriteHeader(http.StatusFound)
-		case r.URL.Path == "/direct/photo.jpg":
+		case "/direct/photo.jpg":
 			w.Header().Set("Content-Type", "image/png")
 			_, _ = w.Write([]byte("png data"))
 		}


### PR DESCRIPTION
## Summary

- add lint, test, and govulncheck GitHub Actions workflows similar to notesctl
- update tag workflow checkout action to v6
- make local lint runnable and address lint findings
- bump Go patch version to 1.25.9 for vulnerability fixes

## Checks

- make test
- make lint
- go run golang.org/x/vuln/cmd/govulncheck@latest ./...
- make build