### PR TITLE
Make npub serve use build_path from config by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.2.2] - 2026-04-30
+
+### Fixed
+
+- `npub serve` now defaults to the configured `build_path` instead of always falling back to `./dist`, so it serves the same directory `npub build` writes to. Pass `--dir` to override.
+
 ## [0.2.1] - 2026-04-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Serve locally:
 npub serve
 ```
 
-The `serve` command starts a local HTTP server on port 4000 (override with `--port`), serving from `dist` (override with `--dir`).
+The `serve` command starts a local HTTP server on port 4000 (override with `--port`), serving from `build_path` resolved from the config — the same directory `npub build` writes to. It honors `--config`, `NPUB_CONFIG`, and `NOTES_PATH` for config discovery, falls back to `./dist` if no config is found, and accepts `--dir` to override explicitly.
 
 ## Notes format
 

--- a/cmd/npub/main.go
+++ b/cmd/npub/main.go
@@ -75,6 +75,12 @@ var serveCmd = &cobra.Command{
 		dir, _ := cmd.Flags().GetString("dir")
 		port, _ := cmd.Flags().GetString("port")
 
+		if !cmd.Flags().Changed("dir") {
+			cfgPath, _ := cmd.Flags().GetString("config")
+			if cfg, err := loadConfig(cmd, cfgPath); err == nil && cfg.BuildPath != "" {
+				dir = cfg.BuildPath
+			}
+		}
 		if dir == "" {
 			dir = "./dist"
 		}
@@ -188,8 +194,10 @@ func init() {
 	buildCmd.Flags().String("license-name", "", "license name (default: CC BY 4.0)")
 	buildCmd.Flags().String("license-url", "", "license URL (default: https://creativecommons.org/licenses/by/4.0/)")
 
-	serveCmd.Flags().String("dir", "./dist", "directory to serve")
+	serveCmd.Flags().String("dir", "./dist", "directory to serve (defaults to build_path from config)")
 	serveCmd.Flags().String("port", "4000", "port to listen on")
+	serveCmd.Flags().String("config", "", "config file path (default: npub.yml)")
+	serveCmd.Flags().String("notes", "", "notes store path")
 
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(buildCmd)

--- a/cmd/npub/main.go
+++ b/cmd/npub/main.go
@@ -77,7 +77,12 @@ var serveCmd = &cobra.Command{
 
 		if !cmd.Flags().Changed("dir") {
 			cfgPath, _ := cmd.Flags().GetString("config")
-			if cfg, err := loadConfig(cmd, cfgPath); err == nil && cfg.BuildPath != "" {
+			explicitConfig := cmd.Flags().Changed("config") || os.Getenv("NPUB_CONFIG") != ""
+			cfg, err := loadConfig(cmd, cfgPath)
+			switch {
+			case err != nil && explicitConfig:
+				return err
+			case err == nil && cfg.BuildPath != "":
 				dir = cfg.BuildPath
 			}
 		}


### PR DESCRIPTION
## Summary

Updated the `npub serve` command to respect the `build_path` configuration setting from the config file, making it serve the same directory that `npub build` writes to by default. The `--dir` flag can still be used to override this behavior explicitly.

## Changes

- Modified `serveCmd` to load and use `build_path` from the config file when the `--dir` flag is not explicitly provided
- Added `--config` and `--notes` flags to the serve command for consistency with config discovery
- Updated documentation to reflect the new behavior and config discovery mechanism
- Updated CHANGELOG with the fix details
