### PR TITLE
Rename notes flag to path and simplify serve command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.2.3] - 2026-04-30
+
+### Changed
+
+- Rename `npub serve --dir` to `--path`. The flag now defaults to `$NOTES_PATH` and falls back to the current directory; `serve` no longer reads the config or accepts `--config`/`--notes`.
+- Rename `npub build --notes` to `--path`, with help text `notes store path (default: NOTES_PATH)`.
+
 ## [0.2.2] - 2026-04-30
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,13 @@
 
 ### Changed
 
-- Rename `npub serve --dir` to `--path`. The flag now defaults to `$NOTES_PATH` and falls back to the current directory; `serve` no longer reads the config or accepts `--config`/`--notes`.
-- Rename `npub build --notes` to `--path`, with help text `notes store path (default: NOTES_PATH)`.
+- Rename `--dir`/`--notes` to `--path` on `npub serve` and `npub build`. Both flags now share the help text `notes path (default: NOTES_PATH)` and resolve from `--path` then `$NOTES_PATH`.
+- `npub serve` no longer reads the config or accepts `--config`/`--notes`.
+- Suppress cobra's usage dump on command errors so error messages stand alone.
+
+### Fixed
+
+- `npub serve` and `npub build` now fail fast with explicit messages when the notes path is unset, missing, inaccessible, or not a directory, instead of failing later with an opaque error.
 
 ## [0.2.2] - 2026-04-30
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Serve locally:
 npub serve
 ```
 
-The `serve` command starts a local HTTP server on port 4000 (override with `--port`), serving from `build_path` resolved from the config — the same directory `npub build` writes to. It honors `--config`, `NPUB_CONFIG`, and `NOTES_PATH` for config discovery, falls back to `./dist` if no config is found, and accepts `--dir` to override explicitly.
+The `serve` command starts a local HTTP server on port 4000 (override with `--port`). Pass `--path` to choose the directory or file to serve; it defaults to `$NOTES_PATH` and falls back to the current directory.
 
 ## Notes format
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Serve locally:
 npub serve
 ```
 
-The `serve` command starts a local HTTP server on port 4000 (override with `--port`). Pass `--path` to choose the directory or file to serve; it defaults to `$NOTES_PATH` and falls back to the current directory.
+The `serve` command starts a local HTTP server on port 4000 (override with `--port`). Pass `--path` to choose the directory to serve, or set `NOTES_PATH`; if neither is set the command fails with an explicit error.
 
 ## Notes format
 

--- a/cmd/npub/main.go
+++ b/cmd/npub/main.go
@@ -72,26 +72,18 @@ var serveCmd = &cobra.Command{
 	Use:   "serve",
 	Short: "Serve the built site locally",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		dir, _ := cmd.Flags().GetString("dir")
+		path, _ := cmd.Flags().GetString("path")
 		port, _ := cmd.Flags().GetString("port")
 
-		if !cmd.Flags().Changed("dir") {
-			cfgPath, _ := cmd.Flags().GetString("config")
-			explicitConfig := cmd.Flags().Changed("config") || os.Getenv("NPUB_CONFIG") != ""
-			cfg, err := loadConfig(cmd, cfgPath)
-			switch {
-			case err != nil && explicitConfig:
-				return err
-			case err == nil && cfg.BuildPath != "":
-				dir = cfg.BuildPath
-			}
+		if path == "" {
+			path = os.Getenv("NOTES_PATH")
 		}
-		if dir == "" {
-			dir = "./dist"
+		if path == "" {
+			path = "."
 		}
 		addr := ":" + port
-		log.Printf("serving %s on http://localhost%s", dir, addr)
-		return http.ListenAndServe(addr, http.FileServer(http.Dir(dir)))
+		log.Printf("serving %s on http://localhost%s", path, addr)
+		return http.ListenAndServe(addr, http.FileServer(http.Dir(path)))
 	},
 }
 
@@ -199,10 +191,8 @@ func init() {
 	buildCmd.Flags().String("license-name", "", "license name (default: CC BY 4.0)")
 	buildCmd.Flags().String("license-url", "", "license URL (default: https://creativecommons.org/licenses/by/4.0/)")
 
-	serveCmd.Flags().String("dir", "./dist", "directory to serve (defaults to build_path from config)")
+	serveCmd.Flags().String("path", "", "notes root path or file (default: $NOTES_PATH, .)")
 	serveCmd.Flags().String("port", "4000", "port to listen on")
-	serveCmd.Flags().String("config", "", "config file path (default: npub.yml)")
-	serveCmd.Flags().String("notes", "", "notes store path")
 
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(buildCmd)

--- a/cmd/npub/main.go
+++ b/cmd/npub/main.go
@@ -20,14 +20,14 @@ var Version = "dev"
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }
 
 var rootCmd = &cobra.Command{
-	Use:   "npub",
-	Short: "Build a static site from a local notes store",
+	Use:          "npub",
+	Short:        "Build a static site from a local notes store",
+	SilenceUsage: true,
 }
 
 var initCmd = &cobra.Command{
@@ -57,6 +57,9 @@ var buildCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		if err := validateNotesPath(cfg.NotesPath); err != nil {
+			return err
+		}
 
 		log.Printf("building site from %s to %s", cfg.NotesPath, cfg.BuildPath)
 		store := note.NewOSStore(cfg.NotesPath)
@@ -72,19 +75,32 @@ var serveCmd = &cobra.Command{
 	Use:   "serve",
 	Short: "Serve the built site locally",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		path, _ := cmd.Flags().GetString("path")
 		port, _ := cmd.Flags().GetString("port")
-
+		path, _ := cmd.Flags().GetString("path")
 		if path == "" {
 			path = os.Getenv("NOTES_PATH")
 		}
-		if path == "" {
-			path = "."
+		if err := validateNotesPath(path); err != nil {
+			return err
 		}
 		addr := ":" + port
 		log.Printf("serving %s on http://localhost%s", path, addr)
 		return http.ListenAndServe(addr, http.FileServer(http.Dir(path)))
 	},
+}
+
+func validateNotesPath(path string) error {
+	if path == "" {
+		return fmt.Errorf("notes path is not set: pass --path or set NOTES_PATH")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("invalid notes path %q: %w", path, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("invalid notes path %q: not a directory", path)
+	}
+	return nil
 }
 
 func initConfig(path string) (string, error) {
@@ -181,7 +197,7 @@ func init() {
 	rootCmd.Version = Version
 
 	buildCmd.Flags().String("config", "", "config file path (default: npub.yml)")
-	buildCmd.Flags().String("path", "", "notes store path (default: NOTES_PATH)")
+	buildCmd.Flags().String("path", "", "notes path (default: NOTES_PATH)")
 	buildCmd.Flags().String("assets", "", "image assets path")
 	buildCmd.Flags().String("out", "", "output directory (default: ./dist)")
 	buildCmd.Flags().String("static", "", "static files directory")
@@ -191,7 +207,7 @@ func init() {
 	buildCmd.Flags().String("license-name", "", "license name (default: CC BY 4.0)")
 	buildCmd.Flags().String("license-url", "", "license URL (default: https://creativecommons.org/licenses/by/4.0/)")
 
-	serveCmd.Flags().String("path", "", "notes root path or file (default: $NOTES_PATH, .)")
+	serveCmd.Flags().String("path", "", "notes path (default: NOTES_PATH)")
 	serveCmd.Flags().String("port", "4000", "port to listen on")
 
 	rootCmd.AddCommand(initCmd)

--- a/cmd/npub/main.go
+++ b/cmd/npub/main.go
@@ -145,13 +145,13 @@ func resolveConfigPath(flagValue, envValue, notesPath string) string {
 func loadConfig(cmd *cobra.Command, cfgPath string) (config.Config, error) {
 	// Resolve notes path here too (not only in config.Load) because config
 	// discovery needs it before the yaml is read.
-	notesPath, _ := cmd.Flags().GetString("notes")
+	notesPath, _ := cmd.Flags().GetString("path")
 	if notesPath == "" {
 		notesPath = os.Getenv("NOTES_PATH")
 	}
 	cfgPath = resolveConfigPath(cfgPath, os.Getenv("NPUB_CONFIG"), notesPath)
 
-	flagNames := []string{"notes", "assets", "out", "static", "url", "site-name", "author", "license-name", "license-url"}
+	flagNames := []string{"path", "assets", "out", "static", "url", "site-name", "author", "license-name", "license-url"}
 	flagOverrides := make(map[string]string)
 	for _, name := range flagNames {
 		if cmd.Flags().Changed(name) {
@@ -181,7 +181,7 @@ func init() {
 	rootCmd.Version = Version
 
 	buildCmd.Flags().String("config", "", "config file path (default: npub.yml)")
-	buildCmd.Flags().String("notes", "", "notes store path")
+	buildCmd.Flags().String("path", "", "notes store path (default: NOTES_PATH)")
 	buildCmd.Flags().String("assets", "", "image assets path")
 	buildCmd.Flags().String("out", "", "output directory (default: ./dist)")
 	buildCmd.Flags().String("static", "", "static files directory")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -85,7 +85,7 @@ func Load(yamlPath string, flagOverrides map[string]string) (Config, error) {
 	}
 
 	flagMap := map[string]*string{
-		"notes":        &cfg.NotesPath,
+		"path":         &cfg.NotesPath,
 		"assets":       &cfg.AssetsPath,
 		"out":          &cfg.BuildPath,
 		"static":       &cfg.StaticPath,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -48,7 +48,7 @@ site_name: "Test Site"
 author_name: "Test Author"
 `)
 
-	cfg, err := Load(yamlPath, map[string]string{"notes": "/flag/notes"})
+	cfg, err := Load(yamlPath, map[string]string{"path": "/flag/notes"})
 	require.NoError(t, err)
 
 	assert.Equal(t, "/flag/notes", cfg.NotesPath)


### PR DESCRIPTION
## Summary

Rename the `--notes` flag to `--path` across the codebase for consistency and clarity. Simplify the `serve` command by removing config file loading and using environment variables (`NOTES_PATH`) as the primary fallback mechanism.

### Changes

- Rename `--notes` flag to `--path` in `buildCmd` and update all references
- Remove config file loading from `serveCmd` and simplify path resolution logic
- Update `serveCmd` to use `NOTES_PATH` environment variable with `.` as final fallback
- Remove unused `--config` and `--notes` flags from `serveCmd`
- Update flag descriptions to document default behavior
- Update config mapping and tests to use new flag name
