### PR TITLE
Add serve --host flag and rename init positional to [dir]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.2.5] - 2026-04-30
+
+### Added
+
+- `npub serve --host` flag (default `localhost`) to control the bind interface. Previously `serve` always bound on all interfaces; the safer default now only listens on loopback. Pass `--host 0.0.0.0` to expose on the LAN.
+
+### Changed
+
+- `npub init`'s positional argument is now `[dir]` (was `[path]`) for clearer naming and to avoid confusion with `--path` (notes path).
+
 ## [0.2.4] - 2026-04-30
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Config file discovery order:
 2. `npub.yml` inside `$NOTES_PATH` (or `--path` value) if it exists
 3. `npub.yml` in the current directory
 
-Run `npub init [path]` to create a commented `npub.yml` sample in a directory. If `path` is omitted, the current directory is used.
+Run `npub init [dir]` to create a commented `npub.yml` sample in a directory. If `dir` is omitted, the current directory is used.
 
 The optional `intro` field renders as a paragraph above the posts list on the index page. Leave it empty or unset to omit.
 
@@ -93,7 +93,7 @@ Serve locally:
 npub serve
 ```
 
-The `serve` command starts a local HTTP server on port 4000 (override with `--port`). It serves the `build_path` from your config (or `./dist` if no config is found). Override with `--dir`.
+The `serve` command starts a local HTTP server on `localhost:4000` (override with `--host` and `--port`). It serves the `build_path` from your config (or `./dist` if no config is found). Override with `--dir`.
 
 ## Notes format
 

--- a/cmd/npub/main.go
+++ b/cmd/npub/main.go
@@ -31,7 +31,7 @@ var rootCmd = &cobra.Command{
 }
 
 var initCmd = &cobra.Command{
-	Use:   "init [path]",
+	Use:   "init [dir]",
 	Short: "Create a sample npub configuration",
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -75,6 +75,7 @@ var serveCmd = &cobra.Command{
 	Use:   "serve",
 	Short: "Serve the built site locally",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		host, _ := cmd.Flags().GetString("host")
 		port, _ := cmd.Flags().GetString("port")
 		dir, _ := cmd.Flags().GetString("dir")
 		if dir == "" {
@@ -99,8 +100,8 @@ var serveCmd = &cobra.Command{
 		if !info.IsDir() {
 			return fmt.Errorf("cannot serve %q: not a directory", dir)
 		}
-		addr := ":" + port
-		log.Printf("serving %s on http://localhost%s", dir, addr)
+		addr := host + ":" + port
+		log.Printf("serving %s on http://%s", dir, addr)
 		return http.ListenAndServe(addr, http.FileServer(http.Dir(dir)))
 	},
 }
@@ -222,6 +223,7 @@ func init() {
 
 	serveCmd.Flags().String("config", "", "config file path (default: npub.yml)")
 	serveCmd.Flags().String("dir", "", "directory to serve (default: build_path from config, or ./dist)")
+	serveCmd.Flags().String("host", "localhost", "interface to bind")
 	serveCmd.Flags().String("port", "4000", "port to listen on")
 
 	rootCmd.AddCommand(initCmd)


### PR DESCRIPTION
## Summary

- Add `npub serve --host` (default `localhost`) so the dev server no longer binds on all interfaces by default. Override with `--host 0.0.0.0` to expose it on the LAN.
- Rename `npub init`'s positional from `[path]` to `[dir]`. The directory the config is created in isn't a "path" in the same sense as `--path` (notes source); `[dir]` reads more accurately and avoids overloading the term.

## Test plan

- [x] `npub serve` binds only on `localhost:4000` by default
- [x] `npub serve --host 0.0.0.0` binds on all interfaces
- [x] `npub serve --help` shows `--host` with default `localhost`
- [x] `npub init --help` shows `Usage: npub init [dir]`
- [x] `npub init ./somewhere` still works as before
