### PR TITLE
Use net.Listen for explicit control over server socket

### DIFF
--- a/cmd/npub/main.go
+++ b/cmd/npub/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -101,8 +102,12 @@ var serveCmd = &cobra.Command{
 			return fmt.Errorf("cannot serve %q: not a directory", dir)
 		}
 		addr := host + ":" + port
-		log.Printf("serving %s on http://%s", dir, addr)
-		return http.ListenAndServe(addr, http.FileServer(http.Dir(dir)))
+		ln, err := net.Listen("tcp", addr)
+		if err != nil {
+			return err
+		}
+		log.Printf("serving %s on http://%s", dir, ln.Addr().String())
+		return http.Serve(ln, http.FileServer(http.Dir(dir)))
 	},
 }
 


### PR DESCRIPTION
## Summary

Refactor the `serve` command to use `net.Listen` instead of `http.ListenAndServe`. This provides explicit control over the listener socket and allows us to log the actual bound address.

**Changes:**
- Import `net` package
- Replace `http.ListenAndServe` with `net.Listen` followed by `http.Serve`
- Update logging to use the actual listener address via `ln.Addr().String()` instead of the user-provided address string

This ensures the logged address matches what the server is actually bound to, which is particularly useful when the port is set to `0` (allowing the OS to assign an available port).

## References

- Closes https://github.com/dreikanter/npub/issues/55