### PR TITLE
Improve CLI error message consistency and clarity

### DIFF
--- a/cmd/npub/main.go
+++ b/cmd/npub/main.go
@@ -58,7 +58,7 @@ var buildCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if err := validateNotesPath(cfg.NotesPath); err != nil {
+		if err := validateNotesPath(cfg.NotesPath, "path"); err != nil {
 			return err
 		}
 
@@ -79,7 +79,8 @@ var serveCmd = &cobra.Command{
 		host, _ := cmd.Flags().GetString("host")
 		port, _ := cmd.Flags().GetString("port")
 		dir, _ := cmd.Flags().GetString("dir")
-		if dir == "" {
+		explicitDir := cmd.Flags().Changed("dir")
+		if !explicitDir {
 			cfgPath, _ := cmd.Flags().GetString("config")
 			explicitConfig := cmd.Flags().Changed("config")
 			cfgPath = resolveConfigPath(cfgPath, os.Getenv("NOTES_PATH"))
@@ -96,6 +97,9 @@ var serveCmd = &cobra.Command{
 		dir = expandHome(os.ExpandEnv(dir))
 		info, err := os.Stat(dir)
 		if err != nil {
+			if explicitDir {
+				return fmt.Errorf("cannot serve %q: %w", dir, err)
+			}
 			return fmt.Errorf("cannot serve %q: %w (run npub build first)", dir, err)
 		}
 		if !info.IsDir() {
@@ -111,9 +115,9 @@ var serveCmd = &cobra.Command{
 	},
 }
 
-func validateNotesPath(path string) error {
+func validateNotesPath(path, flagName string) error {
 	if path == "" {
-		return fmt.Errorf("notes path is not set: pass --path or set NOTES_PATH")
+		return fmt.Errorf("notes path is not set: pass --%s or set NOTES_PATH", flagName)
 	}
 	info, err := os.Stat(path)
 	if err != nil {
@@ -134,31 +138,31 @@ func initConfig(path string) (string, error) {
 	info, err := os.Stat(path)
 	if err != nil {
 		if !os.IsNotExist(err) {
-			return "", fmt.Errorf("cannot inspect %s: %w", path, err)
+			return "", err
 		}
 		if err := os.MkdirAll(path, 0o755); err != nil {
-			return "", fmt.Errorf("cannot create directory %s: %w", path, err)
+			return "", fmt.Errorf("cannot create directory %q: %w", path, err)
 		}
 	} else if !info.IsDir() {
-		return "", fmt.Errorf("%s is not a directory", path)
+		return "", fmt.Errorf("%q is not a directory", path)
 	}
 
 	cfgPath := filepath.Join(path, config.DefaultConfigFile)
 	file, err := os.OpenFile(cfgPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
 	if err != nil {
 		if os.IsExist(err) {
-			return "", fmt.Errorf("config file already exists: %s", cfgPath)
+			return "", fmt.Errorf("config file already exists: %q", cfgPath)
 		}
-		return "", fmt.Errorf("cannot create config file %s: %w", cfgPath, err)
+		return "", fmt.Errorf("cannot create config file %q: %w", cfgPath, err)
 	}
 	if _, err := file.Write(npub.SampleConfig); err != nil {
 		_ = file.Close()
 		_ = os.Remove(cfgPath)
-		return "", fmt.Errorf("cannot write config file %s: %w", cfgPath, err)
+		return "", fmt.Errorf("cannot write config file %q: %w", cfgPath, err)
 	}
 	if err := file.Close(); err != nil {
 		_ = os.Remove(cfgPath)
-		return "", fmt.Errorf("cannot write config file %s: %w", cfgPath, err)
+		return "", fmt.Errorf("cannot write config file %q: %w", cfgPath, err)
 	}
 	return cfgPath, nil
 }

--- a/cmd/npub/main.go
+++ b/cmd/npub/main.go
@@ -58,7 +58,7 @@ var buildCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if err := validateNotesPath(cfg.NotesPath, "path"); err != nil {
+		if err := validateNotesPath(cfg.NotesPath); err != nil {
 			return err
 		}
 
@@ -115,9 +115,9 @@ var serveCmd = &cobra.Command{
 	},
 }
 
-func validateNotesPath(path, flagName string) error {
+func validateNotesPath(path string) error {
 	if path == "" {
-		return fmt.Errorf("notes path is not set: pass --%s or set NOTES_PATH", flagName)
+		return fmt.Errorf("notes path is not set: pass --path or set NOTES_PATH")
 	}
 	info, err := os.Stat(path)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -76,12 +76,12 @@ func (c Config) FeedPath() string {
 func Load(yamlPath string, flagOverrides map[string]string) (Config, error) {
 	data, err := os.ReadFile(yamlPath)
 	if err != nil {
-		return Config{}, fmt.Errorf("cannot read config: %w", err)
+		return Config{}, fmt.Errorf("cannot read config %q: %w", yamlPath, err)
 	}
 
 	var cfg Config
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return Config{}, fmt.Errorf("cannot parse config: %w", err)
+		return Config{}, fmt.Errorf("cannot parse config %q: %w", yamlPath, err)
 	}
 
 	flagMap := map[string]*string{
@@ -125,14 +125,18 @@ func Load(yamlPath string, flagOverrides map[string]string) (Config, error) {
 		cfg.LicenseURL = "https://creativecommons.org/licenses/by/4.0/"
 	}
 
+	var missing []string
 	if cfg.SiteRootURL == "" {
-		return Config{}, fmt.Errorf("site_root_url is required")
+		missing = append(missing, "site_root_url")
 	}
 	if cfg.SiteName == "" {
-		return Config{}, fmt.Errorf("site_name is required")
+		missing = append(missing, "site_name")
 	}
 	if cfg.AuthorName == "" {
-		return Config{}, fmt.Errorf("author_name is required")
+		missing = append(missing, "author_name")
+	}
+	if len(missing) > 0 {
+		return Config{}, fmt.Errorf("missing required fields: %s", strings.Join(missing, ", "))
 	}
 
 	return cfg, nil


### PR DESCRIPTION
## Changes

- **`serve` hint** — `(run npub build first)` is now appended only when `--dir` was not explicitly set; an explicit `--dir` returns just the underlying error.
- **`init` redundant path** — `cannot inspect <path>: stat <path>: ...` collapsed; the `os.Stat` error already names the path.
- **Path quoting** — all path interpolations in error strings now use `%q` (consistent across `validateNotesPath`, `initConfig`, `serveCmd`, and `config.Load`).
- **Aggregated required-field errors** — `config.Load` collects all missing required fields and reports them in one error: `missing required fields: site_root_url, site_name, author_name`.
- **Config path in read failures** — `cannot read config <path>: ...` (and `cannot parse config <path>: ...`) include the resolved YAML path.

## Not done

- Issue #56 item 4 (parameterize `validateNotesPath`'s flag name): an earlier commit added a `flagName` parameter, but it just moved the hardcoded `"path"` to the call site without preventing drift — `--path` is also hardcoded at the flag definition and in `loadConfig`/`config.Load`'s flag lists. Reverted.

## References

- Closes #56