### PR TITLE
Drop dead BuildPath guard in serveCmd config switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.6] - 2026-04-30
+
+### Fixed
+
+- Drop dead `cfg.BuildPath != ""` guard in `serveCmd`'s config-resolution switch. `config.Load` always defaults `cfg.BuildPath` to `./dist` when the YAML omits it, so the guard never failed. ([#66])
+
+[#66]: https://github.com/dreikanter/npub/pull/66
+
 ## [0.2.5] - 2026-04-30
 
 ### Added

--- a/cmd/npub/main.go
+++ b/cmd/npub/main.go
@@ -88,7 +88,7 @@ var serveCmd = &cobra.Command{
 			switch {
 			case err != nil && explicitConfig:
 				return err
-			case err == nil && cfg.BuildPath != "":
+			case err == nil:
 				dir = cfg.BuildPath
 			default:
 				dir = "./dist"


### PR DESCRIPTION
## Summary

- `serveCmd`'s config-resolution switch in `cmd/npub/main.go` had a `cfg.BuildPath != ""` guard that could never fail: `config.Load` always defaults `cfg.BuildPath` to `./dist` when the YAML omits it (`internal/config/config.go:109-110`). Drop the dead guard so `err == nil` directly assigns `dir = cfg.BuildPath`.

## References

- Closes #57


---
_Generated by [Claude Code](https://claude.ai/code/session_01LsVqJLUhhXBkp33dLMnSnR)_