### PR TITLE
Move --config to root as a persistent flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.8] - 2026-04-30
+
+### Changed
+
+- Move `--config` from `build` and `serve` to a `rootCmd` persistent flag. The two identical declarations are now a single one, so future subcommands inherit it for free and `--config` shows up under `npub --help`. `cmd.Flags().GetString("config")` already resolves persistent flags, so `RunE` handlers are unchanged. ([#68])
+
+[#68]: https://github.com/dreikanter/npub/pull/68
+
 ## [0.2.7] - 2026-04-30
 
 ### Fixed

--- a/cmd/npub/main.go
+++ b/cmd/npub/main.go
@@ -208,7 +208,8 @@ func init() {
 	}
 	rootCmd.Version = Version
 
-	buildCmd.Flags().String("config", "", "config file path (default: npub.yml)")
+	rootCmd.PersistentFlags().String("config", "", "config file path (default: npub.yml)")
+
 	buildCmd.Flags().String("path", "", "notes path (default: NOTES_PATH)")
 	buildCmd.Flags().String("assets", "", "image assets path")
 	buildCmd.Flags().String("out", "", "output directory (default: ./dist)")
@@ -219,7 +220,6 @@ func init() {
 	buildCmd.Flags().String("license-name", "", "license name (default: CC BY 4.0)")
 	buildCmd.Flags().String("license-url", "", "license URL (default: https://creativecommons.org/licenses/by/4.0/)")
 
-	serveCmd.Flags().String("config", "", "config file path (default: npub.yml)")
 	serveCmd.Flags().String("dir", "", "directory to serve (default: build_path from config, or ./dist)")
 	serveCmd.Flags().String("host", "localhost", "interface to bind")
 	serveCmd.Flags().String("port", "4000", "port to listen on")


### PR DESCRIPTION
## Summary

- Replace the duplicated `--config` declarations on `buildCmd` and `serveCmd` with a single `rootCmd.PersistentFlags()` registration. Future subcommands inherit it for free, and `--config` now appears under `npub --help`.
- `cmd.Flags().GetString("config")` already resolves persistent flags, so `RunE` handlers are unchanged.

## References

- Closes #59