### PR TITLE
Share config-discovery between build and serve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.9] - 2026-04-30
+
+### Changed
+
+- Share config-discovery between `build` and `serve` via `loadConfigOpt(cmd, cfgPath, optional bool)`. `build` calls it strict; `serve` calls it optional and gets a `BuildPath: "./dist"` fallback when config is missing and `--config` wasn't set explicitly. Guard the internal `--path` lookup with `Flags().Lookup("path") != nil` so future subcommands without that flag don't silently get an empty notes path. ([#69])
+
+[#69]: https://github.com/dreikanter/npub/pull/69
+
 ## [0.2.8] - 2026-04-30
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Share config-discovery between `build` and `serve` via `loadConfigOpt(cmd, cfgPath, optional bool)`. `build` calls it strict; `serve` calls it optional and gets a `BuildPath: "./dist"` fallback when config is missing and `--config` wasn't set explicitly. Guard the internal `--path` lookup with `Flags().Lookup("path") != nil` so future subcommands without that flag don't silently get an empty notes path. ([#69])
+- Share config-discovery between `build` and `serve`. `build` calls `loadConfig` (strict); `serve` calls `loadConfigOpt`, a thin wrapper that falls back to `BuildPath: "./dist"` when the config is missing/invalid and `--config` wasn't set explicitly. Guard the internal `--path` lookup with `Flags().Lookup("path") != nil` so future subcommands without that flag don't silently get an empty notes path. ([#69])
 
 [#69]: https://github.com/dreikanter/npub/pull/69
 

--- a/cmd/npub/main.go
+++ b/cmd/npub/main.go
@@ -53,7 +53,7 @@ var buildCmd = &cobra.Command{
 	Short: "Build the static site",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfgPath, _ := cmd.Flags().GetString("config")
-		cfg, err := loadConfigOpt(cmd, cfgPath, false)
+		cfg, err := loadConfig(cmd, cfgPath)
 		if err != nil {
 			return err
 		}
@@ -81,7 +81,7 @@ var serveCmd = &cobra.Command{
 		explicitDir := cmd.Flags().Changed("dir")
 		if !explicitDir {
 			cfgPath, _ := cmd.Flags().GetString("config")
-			cfg, err := loadConfigOpt(cmd, cfgPath, true)
+			cfg, err := loadConfigOpt(cmd, cfgPath)
 			if err != nil {
 				return err
 			}
@@ -173,7 +173,7 @@ func resolveConfigPath(flagValue, notesPath string) string {
 	return config.DefaultConfigFile
 }
 
-func loadConfigOpt(cmd *cobra.Command, cfgPath string, optional bool) (config.Config, error) {
+func loadConfig(cmd *cobra.Command, cfgPath string) (config.Config, error) {
 	// Resolve notes path here too (not only in config.Load) because config
 	// discovery needs it before the yaml is read.
 	var notesPath string
@@ -193,8 +193,15 @@ func loadConfigOpt(cmd *cobra.Command, cfgPath string, optional bool) (config.Co
 		}
 	}
 
-	cfg, err := config.Load(cfgPath, flagOverrides)
-	if err != nil && optional && !cmd.Flags().Changed("config") {
+	return config.Load(cfgPath, flagOverrides)
+}
+
+// loadConfigOpt loads config like loadConfig but treats a missing/invalid
+// config as non-fatal when --config wasn't set explicitly, returning a
+// minimal default instead.
+func loadConfigOpt(cmd *cobra.Command, cfgPath string) (config.Config, error) {
+	cfg, err := loadConfig(cmd, cfgPath)
+	if err != nil && !cmd.Flags().Changed("config") {
 		return config.Config{BuildPath: "./dist"}, nil
 	}
 	return cfg, err

--- a/cmd/npub/main.go
+++ b/cmd/npub/main.go
@@ -53,7 +53,7 @@ var buildCmd = &cobra.Command{
 	Short: "Build the static site",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfgPath, _ := cmd.Flags().GetString("config")
-		cfg, err := loadConfig(cmd, cfgPath)
+		cfg, err := loadConfigOpt(cmd, cfgPath, false)
 		if err != nil {
 			return err
 		}
@@ -81,17 +81,11 @@ var serveCmd = &cobra.Command{
 		explicitDir := cmd.Flags().Changed("dir")
 		if !explicitDir {
 			cfgPath, _ := cmd.Flags().GetString("config")
-			explicitConfig := cmd.Flags().Changed("config")
-			cfgPath = resolveConfigPath(cfgPath, os.Getenv("NOTES_PATH"))
-			cfg, err := config.Load(cfgPath, nil)
-			switch {
-			case err != nil && explicitConfig:
+			cfg, err := loadConfigOpt(cmd, cfgPath, true)
+			if err != nil {
 				return err
-			case err == nil:
-				dir = cfg.BuildPath
-			default:
-				dir = "./dist"
 			}
+			dir = cfg.BuildPath
 		}
 		dir = config.ExpandPath(dir)
 		info, err := os.Stat(dir)
@@ -179,10 +173,13 @@ func resolveConfigPath(flagValue, notesPath string) string {
 	return config.DefaultConfigFile
 }
 
-func loadConfig(cmd *cobra.Command, cfgPath string) (config.Config, error) {
+func loadConfigOpt(cmd *cobra.Command, cfgPath string, optional bool) (config.Config, error) {
 	// Resolve notes path here too (not only in config.Load) because config
 	// discovery needs it before the yaml is read.
-	notesPath, _ := cmd.Flags().GetString("path")
+	var notesPath string
+	if cmd.Flags().Lookup("path") != nil {
+		notesPath, _ = cmd.Flags().GetString("path")
+	}
 	if notesPath == "" {
 		notesPath = os.Getenv("NOTES_PATH")
 	}
@@ -191,13 +188,16 @@ func loadConfig(cmd *cobra.Command, cfgPath string) (config.Config, error) {
 	flagNames := []string{"path", "assets", "out", "static", "url", "site-name", "author", "license-name", "license-url"}
 	flagOverrides := make(map[string]string)
 	for _, name := range flagNames {
-		if cmd.Flags().Changed(name) {
-			v, _ := cmd.Flags().GetString(name)
-			flagOverrides[name] = v
+		if f := cmd.Flags().Lookup(name); f != nil && f.Changed {
+			flagOverrides[name] = f.Value.String()
 		}
 	}
 
-	return config.Load(cfgPath, flagOverrides)
+	cfg, err := config.Load(cfgPath, flagOverrides)
+	if err != nil && optional && !cmd.Flags().Changed("config") {
+		return config.Config{BuildPath: "./dist"}, nil
+	}
+	return cfg, err
 }
 
 func init() {


### PR DESCRIPTION
## Summary

- Replace the inline config-discovery branch in `serveCmd` with a shared helper. `buildCmd` calls `loadConfig` (strict); `serveCmd` calls `loadConfigOpt`, a thin wrapper that returns a `BuildPath: "./dist"` fallback when the config is missing/invalid and `--config` wasn't set explicitly.
- Guard the internal `--path` lookup with `Flags().Lookup("path") != nil` so future subcommands without that flag don't silently get an empty notes path.

## References

- Closes #60