### PR TITLE
Validate `npub serve --port` as integer in range 1..65535

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.10] - 2026-04-30
+
+### Fixed
+
+- `npub serve --port` is now declared as an `Int` flag, so cobra rejects non-numeric values up front (e.g. `--port abc`) instead of letting `net.Listen` fall back to `/etc/services` lookup with the opaque `lookup tcp/abc: unknown port`. A `validatePort` range check in `RunE` rejects values outside `1..65535` with a clear pre-bind error. ([#70])
+
+[#70]: https://github.com/dreikanter/npub/pull/70
+
 ## [0.2.9] - 2026-04-30
 
 ### Changed

--- a/cmd/npub/main.go
+++ b/cmd/npub/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/debug"
+	"strconv"
 
 	"github.com/dreikanter/notesctl/note"
 	"github.com/dreikanter/npub"
@@ -76,7 +77,10 @@ var serveCmd = &cobra.Command{
 	Short: "Serve the built site locally",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		host, _ := cmd.Flags().GetString("host")
-		port, _ := cmd.Flags().GetString("port")
+		port, _ := cmd.Flags().GetInt("port")
+		if err := validatePort(port); err != nil {
+			return err
+		}
 		dir, _ := cmd.Flags().GetString("dir")
 		explicitDir := cmd.Flags().Changed("dir")
 		if !explicitDir {
@@ -98,7 +102,7 @@ var serveCmd = &cobra.Command{
 		if !info.IsDir() {
 			return fmt.Errorf("cannot serve %q: not a directory", dir)
 		}
-		addr := host + ":" + port
+		addr := host + ":" + strconv.Itoa(port)
 		ln, err := net.Listen("tcp", addr)
 		if err != nil {
 			return err
@@ -106,6 +110,13 @@ var serveCmd = &cobra.Command{
 		log.Printf("serving %s on http://%s", dir, ln.Addr().String())
 		return http.Serve(ln, http.FileServer(http.Dir(dir)))
 	},
+}
+
+func validatePort(port int) error {
+	if port < 1 || port > 65535 {
+		return fmt.Errorf("invalid port %d: must be between 1 and 65535", port)
+	}
+	return nil
 }
 
 func validateNotesPath(path string) error {
@@ -229,7 +240,7 @@ func init() {
 
 	serveCmd.Flags().String("dir", "", "directory to serve (default: build_path from config, or ./dist)")
 	serveCmd.Flags().String("host", "localhost", "interface to bind")
-	serveCmd.Flags().String("port", "4000", "port to listen on")
+	serveCmd.Flags().Int("port", 4000, "port to listen on")
 
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(buildCmd)

--- a/cmd/npub/main_test.go
+++ b/cmd/npub/main_test.go
@@ -66,6 +66,32 @@ func TestInitConfigRejectsNonDirectoryPath(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestValidatePort(t *testing.T) {
+	tests := []struct {
+		name    string
+		port    int
+		wantErr bool
+	}{
+		{name: "lowest valid", port: 1},
+		{name: "common dev port", port: 4000},
+		{name: "highest valid", port: 65535},
+		{name: "zero rejected", port: 0, wantErr: true},
+		{name: "negative rejected", port: -1, wantErr: true},
+		{name: "above range rejected", port: 65536, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePort(tt.port)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "must be between 1 and 65535")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestResolveConfigPath(t *testing.T) {
 	notesDir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(notesDir, config.DefaultConfigFile), []byte("---\n"), 0o644))


### PR DESCRIPTION
## Summary

- Declare `--port` as an `Int` flag so cobra rejects non-numeric values up front (`invalid argument "abc" for "--port" flag: strconv.ParseInt: parsing "abc": invalid syntax`) instead of letting `net.Listen` fall back to `/etc/services` lookup and produce the opaque `lookup tcp/abc: unknown port`.
- Add `validatePort` to range-check `1..65535` in `RunE`, so out-of-range integers fail with `invalid port N: must be between 1 and 65535` before any network call.

## References

- Closes #61
