### PR TITLE
Add `config` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.12] - 2026-04-30
+
+### Added
+
+- `npub config` prints the absolute path of the resolved config file along with the final value of every option after merging YAML, CLI flags, environment variables, and built-in defaults. Accepts the same overrides as `build` so you can preview how a build would see its configuration. When required fields are missing, the partial configuration is still printed and the command exits with an error. ([#73])
+
+[#73]: https://github.com/dreikanter/npub/pull/73
+
 ## [0.2.11] - 2026-04-30
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ Build the site:
 npub build
 ```
 
+Inspect the resolved configuration:
+
+```sh
+npub config
+```
+
+The `config` command prints the absolute path of the config file npub will use along with every option after merging YAML, CLI flags, environment variables, and defaults. It accepts the same overrides as `build`, so `npub config --path ~/notes --url https://example.com` previews how a build would see its configuration.
+
 Serve locally:
 
 ```sh

--- a/cmd/npub/main.go
+++ b/cmd/npub/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -15,6 +16,7 @@ import (
 	"github.com/dreikanter/npub/internal/build"
 	"github.com/dreikanter/npub/internal/config"
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 )
 
 var Version = "dev"
@@ -81,7 +83,7 @@ Examples:
   npub build --path ~/notes --out ./public --url https://example.com`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfgPath, _ := cmd.Flags().GetString("config")
-		cfg, err := loadConfig(cmd, cfgPath)
+		cfg, _, err := loadConfig(cmd, cfgPath)
 		if err != nil {
 			return err
 		}
@@ -97,6 +99,48 @@ Examples:
 		log.Println("build complete")
 		return nil
 	},
+}
+
+var configCmd = &cobra.Command{
+	Use:   "config",
+	Short: "Print resolved configuration",
+	Long: `Print the absolute path of the resolved config file along with the final value
+of every configuration option after merging YAML, CLI flags, environment
+variables, and built-in defaults.
+
+Accepts the same overrides as build, so you can preview how a build would see
+its configuration without running it. When required fields are missing, the
+partial configuration is still printed and the command exits with an error.
+
+Examples:
+  # Show the resolved configuration
+  npub config
+
+  # Preview the effect of overrides
+  npub config --path ~/notes --url https://example.com`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfgFlag, _ := cmd.Flags().GetString("config")
+		cfg, cfgPath, loadErr := loadConfig(cmd, cfgFlag)
+		if abs, err := filepath.Abs(cfgPath); err == nil {
+			cfgPath = abs
+		}
+		if err := printConfig(cmd.OutOrStdout(), cfgPath, cfg); err != nil {
+			return err
+		}
+		return loadErr
+	},
+}
+
+func printConfig(w io.Writer, cfgPath string, cfg config.Config) error {
+	if _, err := fmt.Fprintf(w, "config: %s\n\n", cfgPath); err != nil {
+		return err
+	}
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("cannot marshal config: %w", err)
+	}
+	_, err = w.Write(data)
+	return err
 }
 
 var serveCmd = &cobra.Command{
@@ -226,7 +270,7 @@ func resolveConfigPath(flagValue, notesPath string) string {
 	return config.DefaultConfigFile
 }
 
-func loadConfig(cmd *cobra.Command, cfgPath string) (config.Config, error) {
+func loadConfig(cmd *cobra.Command, cfgPath string) (config.Config, string, error) {
 	// Resolve notes path here too (not only in config.Load) because config
 	// discovery needs it before the yaml is read.
 	var notesPath string
@@ -246,14 +290,15 @@ func loadConfig(cmd *cobra.Command, cfgPath string) (config.Config, error) {
 		}
 	}
 
-	return config.Load(cfgPath, flagOverrides)
+	cfg, err := config.Load(cfgPath, flagOverrides)
+	return cfg, cfgPath, err
 }
 
 // loadConfigOpt loads config like loadConfig but treats a missing/invalid
 // config as non-fatal when --config wasn't set explicitly, returning a
 // minimal default instead.
 func loadConfigOpt(cmd *cobra.Command, cfgPath string) (config.Config, error) {
-	cfg, err := loadConfig(cmd, cfgPath)
+	cfg, _, err := loadConfig(cmd, cfgPath)
 	if err != nil && !cmd.Flags().Changed("config") {
 		return config.Config{BuildPath: "./dist"}, nil
 	}
@@ -270,15 +315,8 @@ func init() {
 
 	rootCmd.PersistentFlags().String("config", "", "config file path (default: npub.yml)")
 
-	buildCmd.Flags().String("path", "", "notes path (default: NOTES_PATH)")
-	buildCmd.Flags().String("assets", "", "image assets path")
-	buildCmd.Flags().String("out", "", "output directory (default: ./dist)")
-	buildCmd.Flags().String("static", "", "static files directory")
-	buildCmd.Flags().String("url", "", "site root URL")
-	buildCmd.Flags().String("site-name", "", "site name")
-	buildCmd.Flags().String("author", "", "author name")
-	buildCmd.Flags().String("license-name", "", "license name (default: CC BY 4.0)")
-	buildCmd.Flags().String("license-url", "", "license URL (default: https://creativecommons.org/licenses/by/4.0/)")
+	addConfigFlags(buildCmd)
+	addConfigFlags(configCmd)
 
 	serveCmd.Flags().String("dir", "", "directory to serve (default: build_path from config, or ./dist)")
 	serveCmd.Flags().String("host", "localhost", "interface to bind")
@@ -286,5 +324,18 @@ func init() {
 
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(buildCmd)
+	rootCmd.AddCommand(configCmd)
 	rootCmd.AddCommand(serveCmd)
+}
+
+func addConfigFlags(cmd *cobra.Command) {
+	cmd.Flags().String("path", "", "notes path (default: NOTES_PATH)")
+	cmd.Flags().String("assets", "", "image assets path")
+	cmd.Flags().String("out", "", "output directory (default: ./dist)")
+	cmd.Flags().String("static", "", "static files directory")
+	cmd.Flags().String("url", "", "site root URL")
+	cmd.Flags().String("site-name", "", "site name")
+	cmd.Flags().String("author", "", "author name")
+	cmd.Flags().String("license-name", "", "license name (default: CC BY 4.0)")
+	cmd.Flags().String("license-url", "", "license URL (default: https://creativecommons.org/licenses/by/4.0/)")
 }

--- a/cmd/npub/main_test.go
+++ b/cmd/npub/main_test.go
@@ -1,14 +1,28 @@
 package main
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/dreikanter/npub/internal/config"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func resetFlags(cmd *cobra.Command) {
+	visit := func(f *pflag.Flag) {
+		f.Changed = false
+		_ = f.Value.Set(f.DefValue)
+	}
+	cmd.PersistentFlags().VisitAll(visit)
+	for _, sub := range cmd.Commands() {
+		sub.Flags().VisitAll(visit)
+	}
+}
 
 func TestInitConfigCreatesSampleInNewDirectory(t *testing.T) {
 	target := filepath.Join(t.TempDir(), "site")
@@ -90,6 +104,93 @@ func TestValidatePort(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConfigCommandPrintsResolvedConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, config.DefaultConfigFile)
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+notes_path: "/tmp/notes"
+site_root_url: "https://example.com"
+site_name: "Test Site"
+author_name: "Test Author"
+`), 0o644))
+
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{"config", "--config", cfgPath})
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+		resetFlags(rootCmd)
+	})
+
+	require.NoError(t, rootCmd.Execute())
+
+	out := buf.String()
+	absPath, err := filepath.Abs(cfgPath)
+	require.NoError(t, err)
+	assert.Contains(t, out, "config: "+absPath)
+	assert.Contains(t, out, "notes_path: /tmp/notes")
+	assert.Contains(t, out, "assets_path: /tmp/notes/images")
+	assert.Contains(t, out, "build_path: ./dist")
+	assert.Contains(t, out, "static_path: /tmp/notes/static")
+	assert.Contains(t, out, "site_root_url: https://example.com")
+	assert.Contains(t, out, "site_name: Test Site")
+	assert.Contains(t, out, "author_name: Test Author")
+	assert.Contains(t, out, "license_name: CC BY 4.0")
+	assert.Contains(t, out, "license_url: https://creativecommons.org/licenses/by/4.0/")
+}
+
+func TestConfigCommandAppliesFlagOverrides(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, config.DefaultConfigFile)
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+notes_path: "/tmp/notes"
+site_root_url: "https://example.com"
+site_name: "Test Site"
+author_name: "Test Author"
+`), 0o644))
+
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{"config", "--config", cfgPath, "--url", "https://override.example.org", "--site-name", "Override"})
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+		resetFlags(rootCmd)
+	})
+
+	require.NoError(t, rootCmd.Execute())
+
+	out := buf.String()
+	assert.Contains(t, out, "site_root_url: https://override.example.org")
+	assert.Contains(t, out, "site_name: Override")
+}
+
+func TestConfigCommandPrintsPartialConfigOnMissingFields(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, config.DefaultConfigFile)
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+notes_path: "/tmp/notes"
+`), 0o644))
+
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{"config", "--config", cfgPath})
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+		resetFlags(rootCmd)
+	})
+
+	err := rootCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing required fields")
+
+	out := buf.String()
+	assert.Contains(t, out, "notes_path: /tmp/notes")
+	assert.Contains(t, out, "build_path: ./dist")
 }
 
 func TestResolveConfigPath(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -136,7 +136,7 @@ func Load(yamlPath string, flagOverrides map[string]string) (Config, error) {
 		missing = append(missing, "author_name")
 	}
 	if len(missing) > 0 {
-		return Config{}, fmt.Errorf("missing required fields: %s", strings.Join(missing, ", "))
+		return cfg, fmt.Errorf("missing required fields: %s", strings.Join(missing, ", "))
 	}
 
 	return cfg, nil


### PR DESCRIPTION
## Summary

- Add `npub config` subcommand that prints the absolute path of the resolved config file along with every option after merging YAML, CLI flags, environment variables, and defaults. Output is YAML for easy diffing.
- Accepts the same overrides as `build` (via a new shared `addConfigFlags` helper), so users can preview how a build would see its configuration without running it.
- When required fields are missing, the partial configuration is still printed and the command exits with the validation error. `config.Load` now returns the parsed `Config` alongside the missing-fields error so the partial state is available to callers.
- `loadConfig` now also returns the resolved `cfgPath`, used by the new command to display the absolute path.

## References

- Closes #72