### PR TITLE
Reorganize help text: move config details to `npub config`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Trim `npub --help` to a one-line `Long` description that points at `npub config` for resolution details. The config-discovery order and `NOTES_PATH` double-duty paragraphs move under `npub config --help`, where they describe how the printed configuration is assembled. ([#74])
+- Trim help text across the CLI for brevity. `npub --help` is a one-line `Long` that points at `npub config` for resolution details. `npub build --help` drops the prose paragraph and the three usage examples in favor of a one-sentence note that flags override YAML. `npub config --help` keeps the resolution details (now the only place they appear) but compacts the discovery list and folds the `NOTES_PATH` double-duty paragraph into a single sentence. `npub serve --help` drops its three examples; the `--dir` fallback note is preserved. ([#74])
 
 [#74]: https://github.com/dreikanter/npub/pull/74
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.13] - 2026-04-30
+
+### Changed
+
+- Trim `npub --help` to a one-line `Long` description that points at `npub config` for resolution details. The config-discovery order and `NOTES_PATH` double-duty paragraphs move under `npub config --help`, where they describe how the printed configuration is assembled. ([#74])
+
+[#74]: https://github.com/dreikanter/npub/pull/74
+
 ## [0.2.12] - 2026-04-30
 
 ### Added

--- a/cmd/npub/main.go
+++ b/cmd/npub/main.go
@@ -28,21 +28,9 @@ func main() {
 }
 
 var rootCmd = &cobra.Command{
-	Use:   "npub",
-	Short: "Build a static site from a local notes store",
-	Long: `npub builds a static site from a directory of Markdown notes.
-
-Configuration is layered: command-line flags (and positional arguments) override
-values from the YAML config file.
-
-Config file discovery order:
-  1. --config flag (if set)
-  2. npub.yml inside $NOTES_PATH (or the --path value, for build)
-  3. npub.yml in the current directory
-
-NOTES_PATH does double duty:
-  1. Source for notes_path when neither --path nor the YAML sets it.
-  2. Hint location for finding npub.yml during config discovery.`,
+	Use:          "npub",
+	Short:        "Build a static site from a local notes store",
+	Long:         `npub builds a static site from a directory of Markdown notes. Run "npub config" to see how flags, environment, and YAML are resolved.`,
 	SilenceUsage: true,
 }
 
@@ -111,6 +99,15 @@ variables, and built-in defaults.
 Accepts the same overrides as build, so you can preview how a build would see
 its configuration without running it. When required fields are missing, the
 partial configuration is still printed and the command exits with an error.
+
+Config file discovery order:
+  1. --config flag (if set)
+  2. npub.yml inside $NOTES_PATH (or the --path value, for build)
+  3. npub.yml in the current directory
+
+NOTES_PATH does double duty:
+  1. Source for notes_path when neither --path nor the YAML sets it.
+  2. Hint location for finding npub.yml during config discovery.
 
 Examples:
   # Show the resolved configuration

--- a/cmd/npub/main.go
+++ b/cmd/npub/main.go
@@ -55,20 +55,8 @@ var initCmd = &cobra.Command{
 var buildCmd = &cobra.Command{
 	Use:   "build",
 	Short: "Build the static site",
-	Long: `Build the static site from notes.
-
-Reads notes from notes_path, renders them to HTML, and writes the result to
-build_path.
-
-Examples:
-  # Use npub.yml from $NOTES_PATH or the current directory
-  npub build
-
-  # Override the config file
-  npub --config ./prod.yml build
-
-  # Override individual settings via flags
-  npub build --path ~/notes --out ./public --url https://example.com`,
+	Long: `Read notes from notes_path, render to HTML, write to build_path. Flags below
+override the corresponding YAML keys.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfgPath, _ := cmd.Flags().GetString("config")
 		cfg, _, err := loadConfig(cmd, cfgPath)
@@ -92,29 +80,18 @@ Examples:
 var configCmd = &cobra.Command{
 	Use:   "config",
 	Short: "Print resolved configuration",
-	Long: `Print the absolute path of the resolved config file along with the final value
-of every configuration option after merging YAML, CLI flags, environment
-variables, and built-in defaults.
+	Long: `Print the resolved config path and final values after merging YAML, CLI flags,
+environment, and defaults. Accepts the same overrides as build, so you can
+preview a build's configuration without running it. If required fields are
+missing, the partial config is still printed and the command exits non-zero.
 
-Accepts the same overrides as build, so you can preview how a build would see
-its configuration without running it. When required fields are missing, the
-partial configuration is still printed and the command exits with an error.
+Config discovery order:
+  1. --config
+  2. $NOTES_PATH/npub.yml (or --path/npub.yml, for build)
+  3. ./npub.yml
 
-Config file discovery order:
-  1. --config flag (if set)
-  2. npub.yml inside $NOTES_PATH (or the --path value, for build)
-  3. npub.yml in the current directory
-
-NOTES_PATH does double duty:
-  1. Source for notes_path when neither --path nor the YAML sets it.
-  2. Hint location for finding npub.yml during config discovery.
-
-Examples:
-  # Show the resolved configuration
-  npub config
-
-  # Preview the effect of overrides
-  npub config --path ~/notes --url https://example.com`,
+NOTES_PATH supplies notes_path when --path and YAML don't set it, and hints
+config discovery.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfgFlag, _ := cmd.Flags().GetString("config")
 		cfg, cfgPath, loadErr := loadConfig(cmd, cfgFlag)
@@ -143,21 +120,8 @@ func printConfig(w io.Writer, cfgPath string, cfg config.Config) error {
 var serveCmd = &cobra.Command{
 	Use:   "serve",
 	Short: "Serve the built site locally",
-	Long: `Serve the built site over HTTP from a local directory.
-
-Without --dir, serve resolves the directory from build_path in the config
-(falling back to ./dist when no config is found). With --dir, the config is
-not consulted.
-
-Examples:
-  # Serve build_path from the discovered config (or ./dist)
-  npub serve
-
-  # Serve a specific directory
-  npub serve --dir ./public
-
-  # Bind to all interfaces on a custom port
-  npub serve --host 0.0.0.0 --port 8080`,
+	Long: `Serve the built site over HTTP. Without --dir, uses build_path from the
+config (falling back to ./dist when no config is found).`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		host, _ := cmd.Flags().GetString("host")
 		port, _ := cmd.Flags().GetInt("port")


### PR DESCRIPTION
## Summary

Streamline the root command's help text by moving detailed configuration discovery and `NOTES_PATH` documentation from `npub --help` to `npub config --help`, where it's more contextually relevant. The root help now provides a concise one-liner that directs users to the `config` command for resolution details.

## Changes

- Trim `npub --help` Long description from multi-paragraph explanation to a single line pointing users to `npub config`
- Move config file discovery order and `NOTES_PATH` double-duty documentation to the `config` command's help text, where they describe how the printed configuration is assembled
- Update CHANGELOG with this change

## References

- Closes #74