### PR TITLE
Simplify note URLs by removing UID from public paths

### DIFF
--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -6,9 +6,11 @@ import (
 	"html/template"
 	"io"
 	"io/fs"
+	"log"
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -199,6 +201,7 @@ func Build(store note.Store, cfg config.Config, assets Assets) error {
 
 	// 2. Build note-page models and the ID → public-path index.
 	notePages, noteIndex := buildNotePages(entries, cfg.SiteRootURL)
+	warnDuplicateSlugs(notePages)
 
 	// 3. Render Markdown for each note (now that noteIndex is complete).
 	imgCache := images.NewCache(cfg.AssetsPath)
@@ -280,19 +283,28 @@ func Build(store note.Store, cfg config.Config, assets Assets) error {
 
 		// Copy attachments.
 		for _, att := range np.Attachments {
-			destDir := filepath.Join(cfg.BuildPath, np.UID, np.Slug)
+			destDir := filepath.Join(cfg.BuildPath, np.Slug)
 			if err := imgCache.CopyTo(images.Entry{FileName: att.FileName, PageUID: att.PageUID}, destDir); err != nil {
 				return fmt.Errorf("copying attachment %s: %w", att.FileName, err)
 			}
 		}
 
-		// Write redirect page.
-		rp := page.RedirectPage{
-			UID:        np.UID,
+		// Write redirect alias for the legacy /<UID>/ path.
+		uidRedirect := page.RedirectPage{
+			FromPath:   np.UID,
 			RedirectTo: "/" + np.PublicPath(),
 		}
-		if err := writeRedirectPage(tmpl, cfg.BuildPath, rp); err != nil {
+		if err := writeRedirectPage(tmpl, cfg.BuildPath, uidRedirect); err != nil {
 			return fmt.Errorf("writing redirect page %s: %w", np.UID, err)
+		}
+
+		// Write redirect alias for the legacy /<UID>/<slug>/ path.
+		legacyRedirect := page.RedirectPage{
+			FromPath:   filepath.ToSlash(filepath.Join(np.UID, np.Slug)),
+			RedirectTo: "/" + np.PublicPath(),
+		}
+		if err := writeRedirectPage(tmpl, cfg.BuildPath, legacyRedirect); err != nil {
+			return fmt.Errorf("writing redirect page %s/%s: %w", np.UID, np.Slug, err)
 		}
 	}
 
@@ -388,6 +400,26 @@ func buildNotePages(entries []note.Entry, siteRootURL string) ([]page.NotePage, 
 		pages = append(pages, np)
 	}
 	return pages, index
+}
+
+// warnDuplicateSlugs logs a warning when multiple notes share the same slug.
+// Duplicates collide on the same output path; the user must rename or set an
+// explicit slug to disambiguate.
+func warnDuplicateSlugs(pages []page.NotePage) {
+	uidsBySlug := make(map[string][]string)
+	for _, p := range pages {
+		uidsBySlug[p.Slug] = append(uidsBySlug[p.Slug], p.UID)
+	}
+	dupes := make([]string, 0)
+	for slug := range uidsBySlug {
+		if len(uidsBySlug[slug]) > 1 {
+			dupes = append(dupes, slug)
+		}
+	}
+	sort.Strings(dupes)
+	for _, slug := range dupes {
+		log.Printf("warning: duplicate slug %q used by notes %s", slug, strings.Join(uidsBySlug[slug], ", "))
+	}
 }
 
 // chooseSlug returns the slug to use for e, falling back from Meta.Slug to

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -1,6 +1,8 @@
 package build
 
 import (
+	"bytes"
+	"log"
 	"os"
 	"path/filepath"
 	"testing"
@@ -8,6 +10,7 @@ import (
 
 	"github.com/dreikanter/notesctl/note"
 	"github.com/dreikanter/npub/internal/config"
+	"github.com/dreikanter/npub/internal/page"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -105,17 +108,22 @@ func TestBuildPublicNote(t *testing.T) {
 	}
 	require.NoError(t, Build(store, cfg, assets))
 
-	notePath := filepath.Join(buildDir, "20230130_3961", "my-test-note", "index.html")
+	notePath := filepath.Join(buildDir, "my-test-note", "index.html")
 	data, err := os.ReadFile(notePath)
 	require.NoError(t, err)
 	html := string(data)
 	assert.Contains(t, html, "My Test Note")
 	assert.Contains(t, html, "<strong>world</strong>")
 
-	redirectPath := filepath.Join(buildDir, "20230130_3961", "index.html")
-	rdata, err := os.ReadFile(redirectPath)
+	uidRedirectPath := filepath.Join(buildDir, "20230130_3961", "index.html")
+	rdata, err := os.ReadFile(uidRedirectPath)
 	require.NoError(t, err)
-	assert.Contains(t, string(rdata), "my-test-note")
+	assert.Contains(t, string(rdata), "/my-test-note")
+
+	legacyRedirectPath := filepath.Join(buildDir, "20230130_3961", "my-test-note", "index.html")
+	ldata, err := os.ReadFile(legacyRedirectPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(ldata), "/my-test-note")
 
 	indexPath := filepath.Join(buildDir, "index.html")
 	idata, err := os.ReadFile(indexPath)
@@ -208,9 +216,9 @@ func TestBuildNoteLinkResolution(t *testing.T) {
 	}
 	require.NoError(t, Build(store, cfg, assets))
 
-	data, err := os.ReadFile(filepath.Join(buildDir, "20230130_3961", "first-note", "index.html"))
+	data, err := os.ReadFile(filepath.Join(buildDir, "first-note", "index.html"))
 	require.NoError(t, err)
-	assert.Contains(t, string(data), `href="/20230131_3962/second-note"`)
+	assert.Contains(t, string(data), `href="/second-note"`)
 }
 
 func TestChooseSlug(t *testing.T) {
@@ -240,6 +248,30 @@ func TestChooseSlug(t *testing.T) {
 			assert.Equal(t, tt.want, chooseSlug(tt.entry))
 		})
 	}
+}
+
+func TestWarnDuplicateSlugs(t *testing.T) {
+	var buf bytes.Buffer
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(os.Stderr)
+		log.SetFlags(log.LstdFlags)
+	})
+
+	pages := []page.NotePage{
+		{UID: "20230130_3961", Slug: "hello-world"},
+		{UID: "20230201_3962", Slug: "unique"},
+		{UID: "20230205_3963", Slug: "hello-world"},
+	}
+
+	warnDuplicateSlugs(pages)
+
+	out := buf.String()
+	assert.Contains(t, out, `duplicate slug "hello-world"`)
+	assert.Contains(t, out, "20230130_3961")
+	assert.Contains(t, out, "20230205_3963")
+	assert.NotContains(t, out, "unique")
 }
 
 func TestTitleOrUID(t *testing.T) {

--- a/internal/page/page.go
+++ b/internal/page/page.go
@@ -30,11 +30,11 @@ type Attachment struct {
 }
 
 func (p NotePage) LocalPath() string {
-	return path.Join(p.UID, p.Slug, "index.html")
+	return path.Join(p.Slug, "index.html")
 }
 
 func (p NotePage) PublicPath() string {
-	return path.Join(p.UID, p.Slug)
+	return p.Slug
 }
 
 func (p NotePage) URL() string {
@@ -100,12 +100,12 @@ func AllTags(pages []NotePage) []string {
 }
 
 type RedirectPage struct {
-	UID        string
+	FromPath   string
 	RedirectTo string
 }
 
 func (p RedirectPage) LocalPath() string {
-	return path.Join(p.UID, "index.html")
+	return path.Join(p.FromPath, "index.html")
 }
 
 type TagPage struct {

--- a/internal/page/page_test.go
+++ b/internal/page/page_test.go
@@ -13,7 +13,7 @@ func TestNotePageLocalPath(t *testing.T) {
 		Slug: "rails-devise-manual-password-change",
 	}
 
-	assert.Equal(t, "20230130_3961/rails-devise-manual-password-change/index.html", p.LocalPath())
+	assert.Equal(t, "rails-devise-manual-password-change/index.html", p.LocalPath())
 }
 
 func TestNotePageURL(t *testing.T) {
@@ -23,7 +23,7 @@ func TestNotePageURL(t *testing.T) {
 		SiteRootURL: "https://notes.musayev.com",
 	}
 
-	assert.Equal(t, "https://notes.musayev.com/20230130_3961/rails-devise-manual-password-change", p.URL())
+	assert.Equal(t, "https://notes.musayev.com/rails-devise-manual-password-change", p.URL())
 }
 
 func TestNotePagePublicPath(t *testing.T) {
@@ -32,15 +32,23 @@ func TestNotePagePublicPath(t *testing.T) {
 		Slug: "rails-devise-manual-password-change",
 	}
 
-	assert.Equal(t, "20230130_3961/rails-devise-manual-password-change", p.PublicPath())
+	assert.Equal(t, "rails-devise-manual-password-change", p.PublicPath())
 }
 
 func TestRedirectPageLocalPath(t *testing.T) {
 	p := RedirectPage{
-		UID: "20230130_3961",
+		FromPath: "20230130_3961",
 	}
 
 	assert.Equal(t, "20230130_3961/index.html", p.LocalPath())
+}
+
+func TestRedirectPageLocalPathNested(t *testing.T) {
+	p := RedirectPage{
+		FromPath: "20230130_3961/old-slug",
+	}
+
+	assert.Equal(t, "20230130_3961/old-slug/index.html", p.LocalPath())
 }
 
 func TestTagPageLocalPath(t *testing.T) {

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -26,13 +26,13 @@ func TestRenderFencedCode(t *testing.T) {
 
 func TestRenderNoteLink(t *testing.T) {
 	noteIndex := map[int]string{
-		8823: "20260106_8823/some-slug",
+		8823: "some-slug",
 	}
 	md := "See [this note](8823)\n"
 	html, err := Render(md, noteIndex, nil)
 	require.NoError(t, err)
 
-	assert.Contains(t, string(html), `href="/20260106_8823/some-slug"`)
+	assert.Contains(t, string(html), `href="/some-slug"`)
 }
 
 func TestRenderNoteLinkUnresolved(t *testing.T) {


### PR DESCRIPTION
## Summary

Changes the URL structure for published notes from `/<UID>/<slug>/` to just `/<slug>/`, simplifying public-facing URLs while maintaining backward compatibility through redirect pages.

### Key Changes

- **Simplified note paths**: Notes are now published directly under their slug (e.g., `/my-test-note/`) instead of nested under their UID (e.g., `/20230130_3961/my-test-note/`)
- **Backward compatibility**: Added redirect pages for both legacy URL patterns:
  - `/<UID>/` redirects to `/<slug>/`
  - `/<UID>/<slug>/` redirects to `/<slug>/`
- **Duplicate slug detection**: Added `warnDuplicateSlugs()` function that logs warnings when multiple notes share the same slug, helping users identify and resolve collisions
- **Updated page models**: Modified `NotePage.LocalPath()` and `NotePage.PublicPath()` to exclude UID; updated `RedirectPage` to use generic `FromPath` field for flexibility

## References

- Closes #75