### PR TITLE
Add deploy command to build and push site to git remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Changed
 
-- `build_path` is no longer a YAML key. `npub build` resolves its output directory in this order: `--out` flag, `<cache_path>/build` when `deploy_repo` is set, then `./dist`. `npub serve` follows the same fallback chain when `--dir` is not given. Existing configs with a `build_path` entry continue to load (the value is silently discarded). ([#78])
+- `build_path` is removed. `npub build` resolves its output directory in this order: `--out` flag, `<cache_path>/build` when `deploy_repo` is set, then `./dist`. `npub serve` follows the same fallback chain when `--dir` is not given. Existing configs with a `build_path` key continue to load (the YAML parser silently ignores unknown keys), but the value has no effect. `npub config` no longer prints `build_path`; the resolved path appears in `npub build`'s log line. ([#78])
 
 [#78]: https://github.com/dreikanter/npub/pull/78
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- `npub deploy` builds and publishes the site to a git remote configured via the new `deploy_repo` YAML key. `npub build` writes the rendered site to `~/.cache/npub/<repo>/build` (offline; no git or network involvement); `npub deploy` clones `deploy_repo` into `~/.cache/npub/<repo>/repo` on first use, hard-resets it to the remote default branch on subsequent runs, mirrors `build/` into it (preserving `repo/.git`), commits the diff, and pushes with `git push -u origin HEAD`. Pass `--dry-run` to commit locally without pushing. Errors at every step (missing `git`, malformed `deploy_repo`, clone failure, mismatched origin URL, missing build output, push rejection) surface git's own message rather than a bare exit code. ([#78])
+- `npub deploy` publishes the site to a git remote configured via the new `deploy_repo` YAML key. `npub build` writes the rendered site to `~/.cache/npub/<repo>/build` (offline; no git or network involvement); `npub deploy` keeps a bare clone of `deploy_repo` at `~/.cache/npub/<repo>/git` and uses `build/` as a temporary work-tree via `--git-dir` + `--work-tree`, so a single `git add -A` reconciles changed, added, and deleted files against origin's last published state. No second copy of the site is held on disk. Pass `--dry-run` to commit locally without pushing. Errors at every step (missing `git`, malformed `deploy_repo`, clone failure, mismatched origin URL, missing build output, push rejection) surface git's own message rather than a bare exit code. ([#78])
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Changed
 
-- `build_path` is removed. `npub build` resolves its output directory in this order: `--out` flag, `<cache_path>/build` when `deploy_repo` is set, then `./dist`. `npub serve` follows the same fallback chain when `--dir` is not given. Existing configs with a `build_path` key continue to load (the YAML parser silently ignores unknown keys), but the value has no effect. `npub config` no longer prints `build_path`; the resolved path appears in `npub build`'s log line. ([#78])
+- `build_path` is removed. `npub build` writes to `--out <dir>` if given, otherwise to `<cache_path>/build` (with `cache_path` defaulting to `~/.cache/npub/<repo>`). `npub serve` resolves its target the same way, substituting `--dir` for `--out`. There is no implicit `./dist` fallback any more — one of `deploy_repo` or the per-command flag must be set. `npub config` no longer prints `build_path`; the resolved path appears in `npub build`'s log line. ([#78])
 
 [#78]: https://github.com/dreikanter/npub/pull/78
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.2.14] - 2026-05-01
+
+### Added
+
+- `npub deploy` builds and publishes the site to a git remote configured via the new `deploy_repo` YAML key. `npub build` writes the rendered site to `~/.cache/npub/<repo>/build` (offline; no git or network involvement); `npub deploy` clones `deploy_repo` into `~/.cache/npub/<repo>/repo` on first use, hard-resets it to the remote default branch on subsequent runs, mirrors `build/` into it (preserving `repo/.git`), commits the diff, and pushes with `git push -u origin HEAD`. Pass `--dry-run` to commit locally without pushing. Errors at every step (missing `git`, malformed `deploy_repo`, clone failure, mismatched origin URL, missing build output, push rejection) surface git's own message rather than a bare exit code. ([#78])
+
+### Changed
+
+- `build_path` is no longer a YAML key. `npub build` resolves its output directory in this order: `--out` flag, `~/.cache/npub/<repo>/build` when `deploy_repo` is set, then `./dist`. `npub serve` follows the same fallback chain when `--dir` is not given. Existing configs with a `build_path` entry continue to load (the value is silently discarded). ([#78])
+
+[#78]: https://github.com/dreikanter/npub/pull/78
+
 ## [0.2.13] - 2026-04-30
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@
 
 ### Added
 
-- `npub deploy` publishes the site to a git remote configured via the new `deploy_repo` YAML key. `npub build` writes the rendered site to `~/.cache/npub/<repo>/build` (offline; no git or network involvement); `npub deploy` keeps a bare clone of `deploy_repo` at `~/.cache/npub/<repo>/git` and uses `build/` as a temporary work-tree via `--git-dir` + `--work-tree`, so a single `git add -A` reconciles changed, added, and deleted files against origin's last published state. No second copy of the site is held on disk. Pass `--dry-run` to commit locally without pushing. Errors at every step (missing `git`, malformed `deploy_repo`, clone failure, mismatched origin URL, missing build output, push rejection) surface git's own message rather than a bare exit code. ([#78])
+- `npub deploy` publishes the site to a git remote configured via the new `deploy_repo` YAML key. `npub build` writes the rendered site to `<cache_path>/build` (offline; no git or network involvement); `npub deploy` keeps a bare clone of `deploy_repo` at `<cache_path>/git` and uses `build/` as a temporary work-tree via `--git-dir` + `--work-tree`, so a single `git add -A` reconciles changed, added, and deleted files against origin's last published state. No second copy of the site is held on disk. Pass `--dry-run` to commit locally without pushing. Errors at every step (missing `git`, malformed `deploy_repo`, clone failure, mismatched origin URL, missing build output, push rejection) surface git's own message rather than a bare exit code. ([#78])
+- New `cache_path` YAML key overrides the per-site cache directory. Defaults to `~/.cache/npub/<repo>`. Use it to keep cache state on a different volume or to give multiple `npub.yml` configs distinct cache locations. Honors `~/` and `$VAR` expansion like the other path settings. ([#78])
 
 ### Changed
 
-- `build_path` is no longer a YAML key. `npub build` resolves its output directory in this order: `--out` flag, `~/.cache/npub/<repo>/build` when `deploy_repo` is set, then `./dist`. `npub serve` follows the same fallback chain when `--dir` is not given. Existing configs with a `build_path` entry continue to load (the value is silently discarded). ([#78])
+- `build_path` is no longer a YAML key. `npub build` resolves its output directory in this order: `--out` flag, `<cache_path>/build` when `deploy_repo` is set, then `./dist`. `npub serve` follows the same fallback chain when `--dir` is not given. Existing configs with a `build_path` entry continue to load (the value is silently discarded). ([#78])
 
 [#78]: https://github.com/dreikanter/npub/pull/78
 

--- a/README.md
+++ b/README.md
@@ -30,19 +30,18 @@ Create a `npub.yml` file:
 
 ```yaml
 notes_path: "~/notes"
-build_path: "dist"
 site_root_url: "https://example.com"
 site_name: "My Notes"
 author_name: "Ada Lovelace"
+deploy_repo: "git@github.com:user/site.git"
 ```
 
 All values can be overridden with CLI flags:
 
 | Config option | CLI flag | Default | Required |
 |---|---|---|---|
-| `notes_path` | `--notes` | `$NOTES_PATH` | |
+| `notes_path` | `--path` | `$NOTES_PATH` | |
 | `assets_path` | `--assets` | `<notes_path>/images` | |
-| `build_path` | `--out` | `./dist` | |
 | `static_path` | `--static` | `<notes_path>/static` | |
 | `site_root_url` | `--url` | | Yes |
 | `site_name` | `--site-name` | | Yes |
@@ -51,6 +50,11 @@ All values can be overridden with CLI flags:
 | `license_url` | `--license-url` | https://creativecommons.org/licenses/by/4.0/ | |
 | `intro` | | | |
 | `deploy_repo` | | | For `deploy` |
+
+The build output directory is not a config option. `npub build` writes to
+`~/.cache/npub/<repo>/build` when `deploy_repo` is set, otherwise to
+`./dist`. Pass `--out <dir>` to `npub build` to override. `build` never
+talks to the deploy_repo remote — all git operations happen in `deploy`.
 
 Priority: CLI flags > YAML config.
 
@@ -106,15 +110,18 @@ Serve locally:
 npub serve
 ```
 
-The `serve` command starts a local HTTP server on `localhost:4000` (override with `--host` and `--port`). It serves the `build_path` from your config (or `./dist` if no config is found). Override with `--dir`.
+The `serve` command starts a local HTTP server on `localhost:4000` (override with `--host` and `--port`). It serves the build directory (`~/.cache/npub/<repo>/build` if `deploy_repo` is set, otherwise `./dist`). Override with `--dir`.
 
 Deploy to a git remote:
 
 ```sh
+npub build
 npub deploy
 ```
 
-`npub deploy` builds the site directly into a local working copy of `deploy_repo`, then commits and pushes the result. The working copy is kept in `~/.cache/npub/<repo>`; the first run clones, subsequent runs fetch and hard-reset to the remote default branch before building. Use `--dry-run` to build and commit locally without pushing.
+`npub build` writes the site to `~/.cache/npub/<repo>/build`. It never contacts the remote — everything is offline.
+
+`npub deploy` clones `deploy_repo` into `~/.cache/npub/<repo>/repo` on first use, fetches and hard-resets it to the remote default branch on subsequent runs, then mirrors the contents of `build/` into `repo/` (preserving `repo/.git`), commits the diff, and pushes. Use `--dry-run` to sync and commit locally without pushing.
 
 ## Notes format
 

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ All values can be overridden with CLI flags:
 | `cache_path` | | `~/.cache/npub/<repo>` | |
 
 The build output directory is not a config option. `npub build` writes to
-`<cache_path>/build` when `deploy_repo` is set (where `cache_path` defaults
-to `~/.cache/npub/<repo>`), otherwise to `./dist`. Pass `--out <dir>` to
-`npub build` to override. `build` never talks to the deploy_repo remote —
-all git operations happen in `deploy`.
+`<cache_path>/build` (where `cache_path` defaults to `~/.cache/npub/<repo>`).
+Pass `--out <dir>` to override. Either `deploy_repo` or `--out` must be set;
+there is no implicit `./dist`. `build` never talks to the deploy_repo
+remote — all git operations happen in `deploy`.
 
 Priority: CLI flags > YAML config.
 
@@ -112,7 +112,7 @@ Serve locally:
 npub serve
 ```
 
-The `serve` command starts a local HTTP server on `localhost:4000` (override with `--host` and `--port`). It serves the build directory (`~/.cache/npub/<repo>/build` if `deploy_repo` is set, otherwise `./dist`). Override with `--dir`.
+The `serve` command starts a local HTTP server on `localhost:4000` (override with `--host` and `--port`). It serves `<cache_path>/build` (where `cache_path` defaults to `~/.cache/npub/<repo>`). Pass `--dir <path>` to point it at a different directory; either `deploy_repo` or `--dir` must be set.
 
 Deploy to a git remote:
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ npub deploy
 
 `npub build` writes the site to `~/.cache/npub/<repo>/build`. It never contacts the remote — everything is offline.
 
-`npub deploy` clones `deploy_repo` into `~/.cache/npub/<repo>/repo` on first use, fetches and hard-resets it to the remote default branch on subsequent runs, then mirrors the contents of `build/` into `repo/` (preserving `repo/.git`), commits the diff, and pushes. Use `--dry-run` to sync and commit locally without pushing.
+`npub deploy` keeps a bare clone of `deploy_repo` at `~/.cache/npub/<repo>/git` and uses `~/.cache/npub/<repo>/build` as a temporary work-tree (via git's `--git-dir` and `--work-tree` options) when committing. There is no second copy of the site on disk: deploy fetches, points git at the build directory, and runs `add -A` + commit + push. Stale files are removed and changed files updated by the same `add -A` pass. Use `--dry-run` to commit locally without pushing.
 
 ## Notes format
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ All values can be overridden with CLI flags:
 | `license_name` | `--license-name` | CC BY 4.0 | |
 | `license_url` | `--license-url` | https://creativecommons.org/licenses/by/4.0/ | |
 | `intro` | | | |
+| `deploy_repo` | | | For `deploy` |
 
 Priority: CLI flags > YAML config.
 
@@ -106,6 +107,14 @@ npub serve
 ```
 
 The `serve` command starts a local HTTP server on `localhost:4000` (override with `--host` and `--port`). It serves the `build_path` from your config (or `./dist` if no config is found). Override with `--dir`.
+
+Deploy to a git remote:
+
+```sh
+npub deploy
+```
+
+`npub deploy` builds the site directly into a local working copy of `deploy_repo`, then commits and pushes the result. The working copy is kept in `~/.cache/npub/<repo>`; the first run clones, subsequent runs fetch and hard-reset to the remote default branch before building. Use `--dry-run` to build and commit locally without pushing.
 
 ## Notes format
 

--- a/README.md
+++ b/README.md
@@ -50,11 +50,13 @@ All values can be overridden with CLI flags:
 | `license_url` | `--license-url` | https://creativecommons.org/licenses/by/4.0/ | |
 | `intro` | | | |
 | `deploy_repo` | | | For `deploy` |
+| `cache_path` | | `~/.cache/npub/<repo>` | |
 
 The build output directory is not a config option. `npub build` writes to
-`~/.cache/npub/<repo>/build` when `deploy_repo` is set, otherwise to
-`./dist`. Pass `--out <dir>` to `npub build` to override. `build` never
-talks to the deploy_repo remote — all git operations happen in `deploy`.
+`<cache_path>/build` when `deploy_repo` is set (where `cache_path` defaults
+to `~/.cache/npub/<repo>`), otherwise to `./dist`. Pass `--out <dir>` to
+`npub build` to override. `build` never talks to the deploy_repo remote —
+all git operations happen in `deploy`.
 
 Priority: CLI flags > YAML config.
 

--- a/cmd/npub/main.go
+++ b/cmd/npub/main.go
@@ -58,8 +58,15 @@ var initCmd = &cobra.Command{
 var buildCmd = &cobra.Command{
 	Use:   "build",
 	Short: "Build the static site",
-	Long: `Read notes from notes_path, render to HTML, write to build_path. Flags below
-override the corresponding YAML keys.`,
+	Long: `Read notes from notes_path, render to HTML, and write the site files.
+
+Output directory resolution:
+  --out <dir>              explicit override
+  deploy_repo (in YAML)    ~/.cache/npub/<repo>/build
+  fallback                 ./dist
+
+build runs offline: it never talks to the deploy_repo remote. All git
+operations happen in deploy.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfgPath, _ := cmd.Flags().GetString("config")
 		cfg, _, err := loadConfig(cmd, cfgPath)
@@ -70,10 +77,16 @@ override the corresponding YAML keys.`,
 			return err
 		}
 
+		buildPath, err := resolveBuildPath(cmd, cfg)
+		if err != nil {
+			return err
+		}
+		cfg.BuildPath = buildPath
+
 		log.Printf("building site from %s to %s", cfg.NotesPath, cfg.BuildPath)
 		store := note.NewOSStore(cfg.NotesPath)
 		if err := build.Build(store, cfg, npub.Assets); err != nil {
-			return fmt.Errorf("build failed: %w", err)
+			return err
 		}
 		log.Println("build complete")
 		return nil
@@ -82,19 +95,20 @@ override the corresponding YAML keys.`,
 
 var deployCmd = &cobra.Command{
 	Use:   "deploy",
-	Short: "Build and push the site to a git remote",
-	Long: `Build the site into a local working copy of deploy_repo and push it.
+	Short: "Sync the built site to deploy_repo and push",
+	Long: `Mirror the build output into the deploy_repo working copy, commit, and push.
 
-The working copy lives in ~/.cache/npub/<repo>; npub clones into it on first
-use and hard-resets it to the remote default branch on subsequent runs. With
---dry-run, npub still clones, fetches, and builds, but skips the push.`,
+deploy clones deploy_repo into ~/.cache/npub/<repo>/repo on first use and
+hard-resets it to the remote default branch on subsequent runs. The contents
+of ~/.cache/npub/<repo>/build (produced by npub build) are copied over the
+working copy, .git is preserved, and the resulting diff is committed.
+
+deploy does not rebuild; run npub build first. With --dry-run, deploy
+syncs and commits locally but skips the push.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfgPath, _ := cmd.Flags().GetString("config")
 		cfg, _, err := loadConfig(cmd, cfgPath)
 		if err != nil {
-			return err
-		}
-		if err := validateNotesPath(cfg.NotesPath); err != nil {
 			return err
 		}
 		if strings.TrimSpace(cfg.DeployRepo) == "" {
@@ -102,37 +116,49 @@ use and hard-resets it to the remote default branch on subsequent runs. With
 		}
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 
-		workDir, err := deploy.WorkDir(cfg.DeployRepo)
+		buildDir, err := deploy.BuildDir(cfg.DeployRepo)
 		if err != nil {
 			return err
 		}
-		log.Printf("preparing %s", workDir)
-		if err := deploy.Prepare(cfg.DeployRepo, workDir, deploy.Options{}); err != nil {
+		if _, err := os.Stat(buildDir); err != nil {
+			if os.IsNotExist(err) {
+				return fmt.Errorf("build directory %s does not exist; run `npub build` first", buildDir)
+			}
+			return fmt.Errorf("checking %s: %w", buildDir, err)
+		}
+
+		repoDir, err := deploy.RepoDir(cfg.DeployRepo)
+		if err != nil {
+			return err
+		}
+		log.Printf("preparing %s", repoDir)
+		if err := deploy.Prepare(cfg.DeployRepo, repoDir, deploy.Options{}); err != nil {
 			return err
 		}
 
-		cfg.BuildPath = workDir
-		log.Printf("building site from %s to %s", cfg.NotesPath, cfg.BuildPath)
-		store := note.NewOSStore(cfg.NotesPath)
-		if err := build.Build(store, cfg, npub.Assets); err != nil {
+		log.Printf("syncing %s -> %s", buildDir, repoDir)
+		if err := deploy.Sync(buildDir, repoDir); err != nil {
 			return err
 		}
 
 		message := fmt.Sprintf("Deploy %s", time.Now().UTC().Format(time.RFC3339))
-		committed, err := deploy.Commit(workDir, message, deploy.Options{})
+		committed, err := deploy.Commit(repoDir, message, deploy.Options{})
 		if err != nil {
 			return err
 		}
 		if !committed {
-			log.Println("no changes to deploy")
-			return nil
+			synced, _ := deploy.IsSyncedWithOrigin(repoDir)
+			if synced {
+				log.Println("no changes to deploy")
+				return nil
+			}
 		}
 		if dryRun {
 			log.Println("dry-run: skipping push")
 			return nil
 		}
 		log.Println("pushing")
-		if err := deploy.Push(workDir, deploy.Options{}); err != nil {
+		if err := deploy.Push(repoDir, deploy.Options{}); err != nil {
 			return err
 		}
 		log.Println("deploy complete")
@@ -161,6 +187,9 @@ config discovery.`,
 		if abs, err := filepath.Abs(cfgPath); err == nil {
 			cfgPath = abs
 		}
+		if buildPath, err := resolveBuildPath(cmd, cfg); err == nil {
+			cfg.BuildPath = buildPath
+		}
 		if err := printConfig(cmd.OutOrStdout(), cfgPath, cfg); err != nil {
 			return err
 		}
@@ -183,8 +212,8 @@ func printConfig(w io.Writer, cfgPath string, cfg config.Config) error {
 var serveCmd = &cobra.Command{
 	Use:   "serve",
 	Short: "Serve the built site locally",
-	Long: `Serve the built site over HTTP. Without --dir, uses build_path from the
-config (falling back to ./dist when no config is found).`,
+	Long: `Serve the built site over HTTP. Without --dir, uses the deploy_repo cache
+directory if set, otherwise ./dist.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		host, _ := cmd.Flags().GetString("host")
 		port, _ := cmd.Flags().GetInt("port")
@@ -199,7 +228,11 @@ config (falling back to ./dist when no config is found).`,
 			if err != nil {
 				return err
 			}
-			dir = cfg.BuildPath
+			resolved, rerr := resolveBuildPath(cmd, cfg)
+			if rerr != nil {
+				return rerr
+			}
+			dir = resolved
 		}
 		dir = config.ExpandPath(dir)
 		info, err := os.Stat(dir)
@@ -241,6 +274,22 @@ func validateNotesPath(path string) error {
 		return fmt.Errorf("invalid notes path %q: not a directory", path)
 	}
 	return nil
+}
+
+// resolveBuildPath returns the directory the build will write to.
+//
+// Precedence:
+//  1. --out flag (explicit override)
+//  2. deploy_repo cache (~/.cache/npub/<repo>/build)
+//  3. ./dist
+func resolveBuildPath(cmd *cobra.Command, cfg config.Config) (string, error) {
+	if f := cmd.Flags().Lookup("out"); f != nil && f.Changed {
+		return config.ExpandPath(f.Value.String()), nil
+	}
+	if strings.TrimSpace(cfg.DeployRepo) != "" {
+		return deploy.BuildDir(cfg.DeployRepo)
+	}
+	return "./dist", nil
 }
 
 func initConfig(path string) (string, error) {
@@ -306,7 +355,7 @@ func loadConfig(cmd *cobra.Command, cfgPath string) (config.Config, string, erro
 	}
 	cfgPath = resolveConfigPath(cfgPath, notesPath)
 
-	flagNames := []string{"path", "assets", "out", "static", "url", "site-name", "author", "license-name", "license-url"}
+	flagNames := []string{"path", "assets", "static", "url", "site-name", "author", "license-name", "license-url"}
 	flagOverrides := make(map[string]string)
 	for _, name := range flagNames {
 		if f := cmd.Flags().Lookup(name); f != nil && f.Changed {
@@ -324,7 +373,7 @@ func loadConfig(cmd *cobra.Command, cfgPath string) (config.Config, string, erro
 func loadConfigOpt(cmd *cobra.Command, cfgPath string) (config.Config, error) {
 	cfg, _, err := loadConfig(cmd, cfgPath)
 	if err != nil && !cmd.Flags().Changed("config") {
-		return config.Config{BuildPath: "./dist"}, nil
+		return config.Config{}, nil
 	}
 	return cfg, err
 }
@@ -342,9 +391,11 @@ func init() {
 	addConfigFlags(buildCmd)
 	addConfigFlags(configCmd)
 	addConfigFlags(deployCmd)
-	deployCmd.Flags().Bool("dry-run", false, "build and commit but skip git push")
+	buildCmd.Flags().String("out", "", "output directory (overrides deploy_repo cache; default: ./dist)")
+	configCmd.Flags().String("out", "", "preview build path override")
+	deployCmd.Flags().Bool("dry-run", false, "commit locally but skip git push")
 
-	serveCmd.Flags().String("dir", "", "directory to serve (default: build_path from config, or ./dist)")
+	serveCmd.Flags().String("dir", "", "directory to serve (default: deploy_repo cache or ./dist)")
 	serveCmd.Flags().String("host", "localhost", "interface to bind")
 	serveCmd.Flags().Int("port", 4000, "port to listen on")
 
@@ -358,7 +409,6 @@ func init() {
 func addConfigFlags(cmd *cobra.Command) {
 	cmd.Flags().String("path", "", "notes path (default: NOTES_PATH)")
 	cmd.Flags().String("assets", "", "image assets path")
-	cmd.Flags().String("out", "", "output directory (default: ./dist)")
 	cmd.Flags().String("static", "", "static files directory")
 	cmd.Flags().String("url", "", "site root URL")
 	cmd.Flags().String("site-name", "", "site name")

--- a/cmd/npub/main.go
+++ b/cmd/npub/main.go
@@ -82,11 +82,10 @@ operations happen in deploy.`,
 		if err != nil {
 			return err
 		}
-		cfg.BuildPath = buildPath
 
-		log.Printf("building site from %s to %s", cfg.NotesPath, cfg.BuildPath)
+		log.Printf("building site from %s to %s", cfg.NotesPath, buildPath)
 		store := note.NewOSStore(cfg.NotesPath)
-		if err := build.Build(store, cfg, npub.Assets); err != nil {
+		if err := build.Build(store, cfg, buildPath, npub.Assets); err != nil {
 			return err
 		}
 		log.Println("build complete")
@@ -171,9 +170,6 @@ config discovery.`,
 		cfg, cfgPath, loadErr := loadConfig(cmd, cfgFlag)
 		if abs, err := filepath.Abs(cfgPath); err == nil {
 			cfgPath = abs
-		}
-		if buildPath, err := resolveBuildPath(cmd, cfg); err == nil {
-			cfg.BuildPath = buildPath
 		}
 		if err := printConfig(cmd.OutOrStdout(), cfgPath, cfg); err != nil {
 			return err

--- a/cmd/npub/main.go
+++ b/cmd/npub/main.go
@@ -64,7 +64,8 @@ Output directory resolution:
   --out <dir>              explicit override
   deploy_repo (in YAML)    <cache_path>/build (cache_path defaults to
                            ~/.cache/npub/<repo>)
-  fallback                 ./dist
+
+One of the two must be configured.
 
 build runs offline: it never talks to the deploy_repo remote. All git
 operations happen in deploy.`,
@@ -194,8 +195,8 @@ var serveCmd = &cobra.Command{
 	Use:   "serve",
 	Short: "Serve the built site locally",
 	Long: `Serve the built site over HTTP. Without --dir, uses <cache_path>/build
-when deploy_repo is set (cache_path defaults to ~/.cache/npub/<repo>),
-otherwise ./dist.`,
+where cache_path defaults to ~/.cache/npub/<repo>; deploy_repo must be
+set in the config for the implicit path to resolve.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		host, _ := cmd.Flags().GetString("host")
 		port, _ := cmd.Flags().GetInt("port")
@@ -268,24 +269,27 @@ func resolveCacheDir(cfg config.Config) (string, error) {
 	return deploy.DefaultCacheDir(cfg.DeployRepo)
 }
 
-// resolveBuildPath returns the directory the build will write to.
-//
-// Precedence:
-//  1. --out flag (explicit override)
-//  2. <cache_dir>/build when deploy_repo is set
-//  3. ./dist
+// resolveBuildPath returns the directory the build will write to or the
+// directory serve will read from. It honors a caller-provided --out flag
+// first, then falls back to <cache_path>/build when deploy_repo is set.
+// If neither is configured, the caller gets a clear error rather than a
+// surprise relative path.
 func resolveBuildPath(cmd *cobra.Command, cfg config.Config) (string, error) {
 	if f := cmd.Flags().Lookup("out"); f != nil && f.Changed {
 		return config.ExpandPath(f.Value.String()), nil
 	}
-	if strings.TrimSpace(cfg.DeployRepo) != "" {
-		cache, err := resolveCacheDir(cfg)
-		if err != nil {
-			return "", err
+	if strings.TrimSpace(cfg.DeployRepo) == "" {
+		flag := "--out"
+		if cmd.Name() == "serve" {
+			flag = "--dir"
 		}
-		return deploy.BuildDir(cache), nil
+		return "", fmt.Errorf("deploy_repo is not set; configure it in %s or pass %s", config.DefaultConfigFile, flag)
 	}
-	return "./dist", nil
+	cache, err := resolveCacheDir(cfg)
+	if err != nil {
+		return "", err
+	}
+	return deploy.BuildDir(cache), nil
 }
 
 func initConfig(path string) (string, error) {
@@ -386,11 +390,11 @@ func init() {
 
 	addConfigFlags(buildCmd)
 	addConfigFlags(configCmd)
-	buildCmd.Flags().String("out", "", "output directory (overrides deploy_repo cache; defaults to <cache_path>/build, or ./dist)")
+	buildCmd.Flags().String("out", "", "output directory (overrides the deploy_repo cache build path)")
 	configCmd.Flags().String("out", "", "preview build path override")
 	deployCmd.Flags().Bool("dry-run", false, "commit locally but skip git push")
 
-	serveCmd.Flags().String("dir", "", "directory to serve (default: deploy_repo cache or ./dist)")
+	serveCmd.Flags().String("dir", "", "directory to serve (defaults to the deploy_repo cache build path)")
 	serveCmd.Flags().String("host", "localhost", "interface to bind")
 	serveCmd.Flags().Int("port", 4000, "port to listen on")
 

--- a/cmd/npub/main.go
+++ b/cmd/npub/main.go
@@ -95,16 +95,15 @@ operations happen in deploy.`,
 
 var deployCmd = &cobra.Command{
 	Use:   "deploy",
-	Short: "Sync the built site to deploy_repo and push",
-	Long: `Mirror the build output into the deploy_repo working copy, commit, and push.
+	Short: "Commit and push the built site to deploy_repo",
+	Long: `Commit the contents of the build directory to deploy_repo and push.
 
-deploy clones deploy_repo into ~/.cache/npub/<repo>/repo on first use and
-hard-resets it to the remote default branch on subsequent runs. The contents
-of ~/.cache/npub/<repo>/build (produced by npub build) are copied over the
-working copy, .git is preserved, and the resulting diff is committed.
+deploy maintains a bare clone of deploy_repo at ~/.cache/npub/<repo>/git
+and uses ~/.cache/npub/<repo>/build (produced by npub build) as a temporary
+work-tree when committing. No second copy of the site is kept on disk.
 
 deploy does not rebuild; run npub build first. With --dry-run, deploy
-syncs and commits locally but skips the push.`,
+commits locally but skips the push.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfgPath, _ := cmd.Flags().GetString("config")
 		cfg, _, err := loadConfig(cmd, cfgPath)
@@ -120,45 +119,31 @@ syncs and commits locally but skips the push.`,
 		if err != nil {
 			return err
 		}
-		if _, err := os.Stat(buildDir); err != nil {
-			if os.IsNotExist(err) {
-				return fmt.Errorf("build directory %s does not exist; run `npub build` first", buildDir)
-			}
-			return fmt.Errorf("checking %s: %w", buildDir, err)
-		}
-
-		repoDir, err := deploy.RepoDir(cfg.DeployRepo)
+		gitDir, err := deploy.GitDir(cfg.DeployRepo)
 		if err != nil {
 			return err
 		}
-		log.Printf("preparing %s", repoDir)
-		if err := deploy.Prepare(cfg.DeployRepo, repoDir, deploy.Options{}); err != nil {
-			return err
-		}
 
-		log.Printf("syncing %s -> %s", buildDir, repoDir)
-		if err := deploy.Sync(buildDir, repoDir); err != nil {
+		log.Printf("preparing %s", gitDir)
+		if err := deploy.Prepare(cfg.DeployRepo, gitDir, buildDir, deploy.Options{}); err != nil {
 			return err
 		}
 
 		message := fmt.Sprintf("Deploy %s", time.Now().UTC().Format(time.RFC3339))
-		committed, err := deploy.Commit(repoDir, message, deploy.Options{})
+		committed, err := deploy.Commit(gitDir, buildDir, message, deploy.Options{})
 		if err != nil {
 			return err
 		}
 		if !committed {
-			synced, _ := deploy.IsSyncedWithOrigin(repoDir)
-			if synced {
-				log.Println("no changes to deploy")
-				return nil
-			}
+			log.Println("no changes to deploy")
+			return nil
 		}
 		if dryRun {
 			log.Println("dry-run: skipping push")
 			return nil
 		}
 		log.Println("pushing")
-		if err := deploy.Push(repoDir, deploy.Options{}); err != nil {
+		if err := deploy.Push(gitDir, deploy.Options{}); err != nil {
 			return err
 		}
 		log.Println("deploy complete")

--- a/cmd/npub/main.go
+++ b/cmd/npub/main.go
@@ -115,14 +115,12 @@ commits locally but skips the push.`,
 		}
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 
-		buildDir, err := deploy.BuildDir(cfg.DeployRepo)
+		cacheDir, err := resolveCacheDir(cfg)
 		if err != nil {
 			return err
 		}
-		gitDir, err := deploy.GitDir(cfg.DeployRepo)
-		if err != nil {
-			return err
-		}
+		buildDir := deploy.BuildDir(cacheDir)
+		gitDir := deploy.GitDir(cacheDir)
 
 		log.Printf("preparing %s", gitDir)
 		if err := deploy.Prepare(cfg.DeployRepo, gitDir, buildDir, deploy.Options{}); err != nil {
@@ -261,18 +259,32 @@ func validateNotesPath(path string) error {
 	return nil
 }
 
+// resolveCacheDir returns the per-site cache directory that contains
+// build/ and git/ subdirectories. cache_path in the YAML overrides the
+// default ~/.cache/npub/<repo>.
+func resolveCacheDir(cfg config.Config) (string, error) {
+	if strings.TrimSpace(cfg.CachePath) != "" {
+		return config.ExpandPath(cfg.CachePath), nil
+	}
+	return deploy.DefaultCacheDir(cfg.DeployRepo)
+}
+
 // resolveBuildPath returns the directory the build will write to.
 //
 // Precedence:
 //  1. --out flag (explicit override)
-//  2. deploy_repo cache (~/.cache/npub/<repo>/build)
+//  2. <cache_dir>/build when deploy_repo is set
 //  3. ./dist
 func resolveBuildPath(cmd *cobra.Command, cfg config.Config) (string, error) {
 	if f := cmd.Flags().Lookup("out"); f != nil && f.Changed {
 		return config.ExpandPath(f.Value.String()), nil
 	}
 	if strings.TrimSpace(cfg.DeployRepo) != "" {
-		return deploy.BuildDir(cfg.DeployRepo)
+		cache, err := resolveCacheDir(cfg)
+		if err != nil {
+			return "", err
+		}
+		return deploy.BuildDir(cache), nil
 	}
 	return "./dist", nil
 }

--- a/cmd/npub/main.go
+++ b/cmd/npub/main.go
@@ -10,11 +10,13 @@ import (
 	"path/filepath"
 	"runtime/debug"
 	"strconv"
+	"time"
 
 	"github.com/dreikanter/notesctl/note"
 	"github.com/dreikanter/npub"
 	"github.com/dreikanter/npub/internal/build"
 	"github.com/dreikanter/npub/internal/config"
+	"github.com/dreikanter/npub/internal/deploy"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -73,6 +75,66 @@ override the corresponding YAML keys.`,
 			return fmt.Errorf("build failed: %w", err)
 		}
 		log.Println("build complete")
+		return nil
+	},
+}
+
+var deployCmd = &cobra.Command{
+	Use:   "deploy",
+	Short: "Build and push the site to a git remote",
+	Long: `Build the site into a local working copy of deploy_repo and push it.
+
+The working copy lives in ~/.cache/npub/<repo>; npub clones into it on first
+use and hard-resets it to the remote default branch on subsequent runs. With
+--dry-run, npub still clones, fetches, and builds, but skips the push.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfgPath, _ := cmd.Flags().GetString("config")
+		cfg, _, err := loadConfig(cmd, cfgPath)
+		if err != nil {
+			return err
+		}
+		if err := validateNotesPath(cfg.NotesPath); err != nil {
+			return err
+		}
+		if cfg.DeployRepo == "" {
+			return fmt.Errorf("deploy_repo is not set: configure it in npub.yml")
+		}
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+
+		workDir, err := deploy.WorkDir(cfg.DeployRepo)
+		if err != nil {
+			return err
+		}
+		log.Printf("preparing %s", workDir)
+		if err := deploy.Prepare(cfg.DeployRepo, workDir, deploy.Options{}); err != nil {
+			return fmt.Errorf("preparing working copy: %w", err)
+		}
+
+		cfg.BuildPath = workDir
+		log.Printf("building site from %s to %s", cfg.NotesPath, cfg.BuildPath)
+		store := note.NewOSStore(cfg.NotesPath)
+		if err := build.Build(store, cfg, npub.Assets); err != nil {
+			return fmt.Errorf("build failed: %w", err)
+		}
+
+		message := fmt.Sprintf("Deploy %s", time.Now().UTC().Format(time.RFC3339))
+		committed, err := deploy.Commit(workDir, message, deploy.Options{})
+		if err != nil {
+			return fmt.Errorf("commit failed: %w", err)
+		}
+		if !committed {
+			log.Println("no changes to deploy")
+			return nil
+		}
+		if dryRun {
+			log.Println("dry-run: skipping push")
+			return nil
+		}
+		log.Println("pushing")
+		if err := deploy.Push(workDir, deploy.Options{}); err != nil {
+			return fmt.Errorf("push failed: %w", err)
+		}
+		log.Println("deploy complete")
 		return nil
 	},
 }
@@ -278,6 +340,8 @@ func init() {
 
 	addConfigFlags(buildCmd)
 	addConfigFlags(configCmd)
+	addConfigFlags(deployCmd)
+	deployCmd.Flags().Bool("dry-run", false, "build and commit but skip git push")
 
 	serveCmd.Flags().String("dir", "", "directory to serve (default: build_path from config, or ./dist)")
 	serveCmd.Flags().String("host", "localhost", "interface to bind")
@@ -286,6 +350,7 @@ func init() {
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(buildCmd)
 	rootCmd.AddCommand(configCmd)
+	rootCmd.AddCommand(deployCmd)
 	rootCmd.AddCommand(serveCmd)
 }
 

--- a/cmd/npub/main.go
+++ b/cmd/npub/main.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime/debug"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/dreikanter/notesctl/note"
@@ -96,8 +97,8 @@ use and hard-resets it to the remote default branch on subsequent runs. With
 		if err := validateNotesPath(cfg.NotesPath); err != nil {
 			return err
 		}
-		if cfg.DeployRepo == "" {
-			return fmt.Errorf("deploy_repo is not set: configure it in npub.yml")
+		if strings.TrimSpace(cfg.DeployRepo) == "" {
+			return fmt.Errorf("deploy_repo is not set; add it to %s", config.DefaultConfigFile)
 		}
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 
@@ -107,20 +108,20 @@ use and hard-resets it to the remote default branch on subsequent runs. With
 		}
 		log.Printf("preparing %s", workDir)
 		if err := deploy.Prepare(cfg.DeployRepo, workDir, deploy.Options{}); err != nil {
-			return fmt.Errorf("preparing working copy: %w", err)
+			return err
 		}
 
 		cfg.BuildPath = workDir
 		log.Printf("building site from %s to %s", cfg.NotesPath, cfg.BuildPath)
 		store := note.NewOSStore(cfg.NotesPath)
 		if err := build.Build(store, cfg, npub.Assets); err != nil {
-			return fmt.Errorf("build failed: %w", err)
+			return err
 		}
 
 		message := fmt.Sprintf("Deploy %s", time.Now().UTC().Format(time.RFC3339))
 		committed, err := deploy.Commit(workDir, message, deploy.Options{})
 		if err != nil {
-			return fmt.Errorf("commit failed: %w", err)
+			return err
 		}
 		if !committed {
 			log.Println("no changes to deploy")
@@ -132,7 +133,7 @@ use and hard-resets it to the remote default branch on subsequent runs. With
 		}
 		log.Println("pushing")
 		if err := deploy.Push(workDir, deploy.Options{}); err != nil {
-			return fmt.Errorf("push failed: %w", err)
+			return err
 		}
 		log.Println("deploy complete")
 		return nil

--- a/cmd/npub/main.go
+++ b/cmd/npub/main.go
@@ -62,7 +62,8 @@ var buildCmd = &cobra.Command{
 
 Output directory resolution:
   --out <dir>              explicit override
-  deploy_repo (in YAML)    ~/.cache/npub/<repo>/build
+  deploy_repo (in YAML)    <cache_path>/build (cache_path defaults to
+                           ~/.cache/npub/<repo>)
   fallback                 ./dist
 
 build runs offline: it never talks to the deploy_repo remote. All git
@@ -98,12 +99,13 @@ var deployCmd = &cobra.Command{
 	Short: "Commit and push the built site to deploy_repo",
 	Long: `Commit the contents of the build directory to deploy_repo and push.
 
-deploy maintains a bare clone of deploy_repo at ~/.cache/npub/<repo>/git
-and uses ~/.cache/npub/<repo>/build (produced by npub build) as a temporary
-work-tree when committing. No second copy of the site is kept on disk.
+deploy maintains a bare clone of deploy_repo at <cache_path>/git and uses
+<cache_path>/build (produced by npub build) as a temporary work-tree when
+committing. cache_path defaults to ~/.cache/npub/<repo>.
 
-deploy does not rebuild; run npub build first. With --dry-run, deploy
-commits locally but skips the push.`,
+deploy does not rebuild; run npub build first. An empty build directory
+is rejected so a partial or missing build cannot wipe the deployed site.
+With --dry-run, deploy commits locally but skips the push.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfgPath, _ := cmd.Flags().GetString("config")
 		cfg, _, err := loadConfig(cmd, cfgPath)
@@ -195,8 +197,9 @@ func printConfig(w io.Writer, cfgPath string, cfg config.Config) error {
 var serveCmd = &cobra.Command{
 	Use:   "serve",
 	Short: "Serve the built site locally",
-	Long: `Serve the built site over HTTP. Without --dir, uses the deploy_repo cache
-directory if set, otherwise ./dist.`,
+	Long: `Serve the built site over HTTP. Without --dir, uses <cache_path>/build
+when deploy_repo is set (cache_path defaults to ~/.cache/npub/<repo>),
+otherwise ./dist.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		host, _ := cmd.Flags().GetString("host")
 		port, _ := cmd.Flags().GetInt("port")
@@ -387,8 +390,7 @@ func init() {
 
 	addConfigFlags(buildCmd)
 	addConfigFlags(configCmd)
-	addConfigFlags(deployCmd)
-	buildCmd.Flags().String("out", "", "output directory (overrides deploy_repo cache; default: ./dist)")
+	buildCmd.Flags().String("out", "", "output directory (overrides deploy_repo cache; defaults to <cache_path>/build, or ./dist)")
 	configCmd.Flags().String("out", "", "preview build path override")
 	deployCmd.Flags().Bool("dry-run", false, "commit locally but skip git push")
 

--- a/cmd/npub/main_test.go
+++ b/cmd/npub/main_test.go
@@ -38,8 +38,8 @@ func TestInitConfigCreatesSampleInNewDirectory(t *testing.T) {
 	content := string(data)
 	for _, want := range []string{
 		`# notes_path: ""`,
-		`# build_path: "./dist"`,
 		`# license_name: "CC BY 4.0"`,
+		`# deploy_repo: ""`,
 	} {
 		assert.Contains(t, content, want)
 	}
@@ -140,6 +140,7 @@ author_name: "Test Author"
 	assert.Contains(t, out, "author_name: Test Author")
 	assert.Contains(t, out, "license_name: CC BY 4.0")
 	assert.Contains(t, out, "license_url: https://creativecommons.org/licenses/by/4.0/")
+	assert.Contains(t, out, "deploy_repo: \"\"")
 }
 
 func TestConfigCommandAppliesFlagOverrides(t *testing.T) {

--- a/cmd/npub/main_test.go
+++ b/cmd/npub/main_test.go
@@ -133,7 +133,6 @@ author_name: "Test Author"
 	assert.Contains(t, out, "config: "+absPath)
 	assert.Contains(t, out, "notes_path: /tmp/notes")
 	assert.Contains(t, out, "assets_path: /tmp/notes/images")
-	assert.Contains(t, out, "build_path: ./dist")
 	assert.Contains(t, out, "static_path: /tmp/notes/static")
 	assert.Contains(t, out, "site_root_url: https://example.com")
 	assert.Contains(t, out, "site_name: Test Site")
@@ -141,6 +140,7 @@ author_name: "Test Author"
 	assert.Contains(t, out, "license_name: CC BY 4.0")
 	assert.Contains(t, out, "license_url: https://creativecommons.org/licenses/by/4.0/")
 	assert.Contains(t, out, "deploy_repo: \"\"")
+	assert.NotContains(t, out, "build_path:")
 }
 
 func TestConfigCommandAppliesFlagOverrides(t *testing.T) {
@@ -191,7 +191,6 @@ notes_path: "/tmp/notes"
 
 	out := buf.String()
 	assert.Contains(t, out, "notes_path: /tmp/notes")
-	assert.Contains(t, out, "build_path: ./dist")
 }
 
 func TestResolveConfigPath(t *testing.T) {

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -179,16 +179,18 @@ type Assets struct {
 	FaviconSVG []byte
 }
 
-// Build generates the static site from notes.
-func Build(store note.Store, cfg config.Config, assets Assets) error {
+// Build generates the static site from notes into buildPath. buildPath is
+// the directory the rendered files are written to; cfg supplies everything
+// else (notes location, site metadata, etc).
+func Build(store note.Store, cfg config.Config, buildPath string, assets Assets) error {
 	// 0. Clean build directory.
-	if err := cleanBuildDir(cfg.BuildPath); err != nil {
+	if err := cleanBuildDir(buildPath); err != nil {
 		return err
 	}
 
 	// 0b. Copy static files.
 	if cfg.StaticPath != "" {
-		if err := copyStaticFiles(cfg.StaticPath, cfg.BuildPath); err != nil {
+		if err := copyStaticFiles(cfg.StaticPath, buildPath); err != nil {
 			return fmt.Errorf("copying static files: %w", err)
 		}
 	}
@@ -277,13 +279,13 @@ func Build(store note.Store, cfg config.Config, assets Assets) error {
 			CanonicalPath:   np.CanonicalPath(),
 		}
 
-		if err := writeHTMLPage(tmpl, cfg.BuildPath, np.LocalPath(), "note.html", inner, cfgData, pd); err != nil {
+		if err := writeHTMLPage(tmpl, buildPath, np.LocalPath(), "note.html", inner, cfgData, pd); err != nil {
 			return fmt.Errorf("writing note page %s: %w", np.UID, err)
 		}
 
 		// Copy attachments.
 		for _, att := range np.Attachments {
-			destDir := filepath.Join(cfg.BuildPath, np.Slug)
+			destDir := filepath.Join(buildPath, np.Slug)
 			if err := imgCache.CopyTo(images.Entry{FileName: att.FileName, PageUID: att.PageUID}, destDir); err != nil {
 				return fmt.Errorf("copying attachment %s: %w", att.FileName, err)
 			}
@@ -294,7 +296,7 @@ func Build(store note.Store, cfg config.Config, assets Assets) error {
 			FromPath:   np.UID,
 			RedirectTo: "/" + np.PublicPath(),
 		}
-		if err := writeRedirectPage(tmpl, cfg.BuildPath, uidRedirect); err != nil {
+		if err := writeRedirectPage(tmpl, buildPath, uidRedirect); err != nil {
 			return fmt.Errorf("writing redirect page %s: %w", np.UID, err)
 		}
 
@@ -303,7 +305,7 @@ func Build(store note.Store, cfg config.Config, assets Assets) error {
 			FromPath:   filepath.ToSlash(filepath.Join(np.UID, np.Slug)),
 			RedirectTo: "/" + np.PublicPath(),
 		}
-		if err := writeRedirectPage(tmpl, cfg.BuildPath, legacyRedirect); err != nil {
+		if err := writeRedirectPage(tmpl, buildPath, legacyRedirect); err != nil {
 			return fmt.Errorf("writing redirect page %s/%s: %w", np.UID, np.Slug, err)
 		}
 	}
@@ -324,7 +326,7 @@ func Build(store note.Store, cfg config.Config, assets Assets) error {
 		Title:           "",
 		MetaDescription: cfg.SiteName,
 	}
-	if err := writeHTMLPage(tmpl, cfg.BuildPath, "index.html", "index.html", indexInner, cfgData, indexPD); err != nil {
+	if err := writeHTMLPage(tmpl, buildPath, "index.html", "index.html", indexInner, cfgData, indexPD); err != nil {
 		return fmt.Errorf("writing index page: %w", err)
 	}
 
@@ -346,7 +348,7 @@ func Build(store note.Store, cfg config.Config, assets Assets) error {
 			MetaDescription: fmt.Sprintf("Notes tagged with %s", tag),
 			CanonicalPath:   tp.CanonicalPath(),
 		}
-		if err := writeHTMLPage(tmpl, cfg.BuildPath, tp.LocalPath(), "tag.html", tagInner, cfgData, tagPD); err != nil {
+		if err := writeHTMLPage(tmpl, buildPath, tp.LocalPath(), "tag.html", tagInner, cfgData, tagPD); err != nil {
 			return fmt.Errorf("writing tag page %s: %w", tag, err)
 		}
 	}
@@ -365,7 +367,7 @@ func Build(store note.Store, cfg config.Config, assets Assets) error {
 		Config:    cfgData,
 		NotePages: feedNotes,
 	}
-	if err := writeFile(cfg.BuildPath, "feed.xml", func() ([]byte, error) {
+	if err := writeFile(buildPath, "feed.xml", func() ([]byte, error) {
 		var buf strings.Builder
 		if err := feedTmpl.ExecuteTemplate(&buf, "feed.xml", fd); err != nil {
 			return nil, err

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -71,11 +71,10 @@ func TestCleanBuildDirRejectsHome(t *testing.T) {
 	require.Error(t, cleanBuildDir(home))
 }
 
-func testConfig(t *testing.T, buildPath, assetsPath string) config.Config {
+func testConfig(t *testing.T, _, assetsPath string) config.Config {
 	t.Helper()
 	return config.Config{
 		AssetsPath:  assetsPath,
-		BuildPath:   buildPath,
 		SiteRootURL: "https://example.com",
 		SiteName:    "Test Site",
 		AuthorName:  "Test Author",
@@ -106,7 +105,7 @@ func TestBuildPublicNote(t *testing.T) {
 		StyleCSS:   []byte("/* test */"),
 		FaviconSVG: []byte("<svg></svg>"),
 	}
-	require.NoError(t, Build(store, cfg, assets))
+	require.NoError(t, Build(store, cfg, buildDir, assets))
 
 	notePath := filepath.Join(buildDir, "my-test-note", "index.html")
 	data, err := os.ReadFile(notePath)
@@ -169,7 +168,7 @@ func TestBuildSkipsPrivateNote(t *testing.T) {
 		StyleCSS:   []byte("/* test */"),
 		FaviconSVG: []byte("<svg></svg>"),
 	}
-	require.NoError(t, Build(store, cfg, assets))
+	require.NoError(t, Build(store, cfg, buildDir, assets))
 
 	assert.NoDirExists(t, filepath.Join(buildDir, "20230130_3961"))
 
@@ -214,7 +213,7 @@ func TestBuildNoteLinkResolution(t *testing.T) {
 		StyleCSS:   []byte("/* test */"),
 		FaviconSVG: []byte("<svg></svg>"),
 	}
-	require.NoError(t, Build(store, cfg, assets))
+	require.NoError(t, Build(store, cfg, buildDir, assets))
 
 	data, err := os.ReadFile(filepath.Join(buildDir, "first-note", "index.html"))
 	require.NoError(t, err)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -88,7 +88,6 @@ func Load(yamlPath string, flagOverrides map[string]string) (Config, error) {
 	flagMap := map[string]*string{
 		"path":         &cfg.NotesPath,
 		"assets":       &cfg.AssetsPath,
-		"out":          &cfg.BuildPath,
 		"static":       &cfg.StaticPath,
 		"url":          &cfg.SiteRootURL,
 		"site-name":    &cfg.SiteName,
@@ -107,10 +106,10 @@ func Load(yamlPath string, flagOverrides map[string]string) (Config, error) {
 	}
 	cfg.NotesPath = ExpandPath(cfg.NotesPath)
 	cfg.AssetsPath = ExpandPath(cfg.AssetsPath)
-	if cfg.BuildPath == "" {
-		cfg.BuildPath = "./dist"
-	}
-	cfg.BuildPath = ExpandPath(cfg.BuildPath)
+	// BuildPath is resolved by the caller (--out flag, deploy_repo, or
+	// fallback) and is not loaded from YAML, so any value parsed from the
+	// file is discarded here.
+	cfg.BuildPath = ""
 	cfg.StaticPath = ExpandPath(cfg.StaticPath)
 	if cfg.StaticPath == "" && cfg.NotesPath != "" {
 		cfg.StaticPath = filepath.Join(cfg.NotesPath, "static")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,7 +16,6 @@ const DefaultConfigFile = "npub.yml"
 type Config struct {
 	NotesPath   string `yaml:"notes_path"`
 	AssetsPath  string `yaml:"assets_path"`
-	BuildPath   string `yaml:"build_path"`
 	StaticPath  string `yaml:"static_path"`
 	SiteRootURL string `yaml:"site_root_url"`
 	SiteName    string `yaml:"site_name"`
@@ -107,10 +106,6 @@ func Load(yamlPath string, flagOverrides map[string]string) (Config, error) {
 	}
 	cfg.NotesPath = ExpandPath(cfg.NotesPath)
 	cfg.AssetsPath = ExpandPath(cfg.AssetsPath)
-	// BuildPath is resolved by the caller (--out flag, deploy_repo, or
-	// fallback) and is not loaded from YAML, so any value parsed from the
-	// file is discarded here.
-	cfg.BuildPath = ""
 	cfg.StaticPath = ExpandPath(cfg.StaticPath)
 	cfg.CachePath = ExpandPath(cfg.CachePath)
 	if cfg.StaticPath == "" && cfg.NotesPath != "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	LicenseName string `yaml:"license_name"`
 	LicenseURL  string `yaml:"license_url"`
 	Intro       string `yaml:"intro"`
+	DeployRepo  string `yaml:"deploy_repo"`
 }
 
 // SiteRootPath returns the URL path component of SiteRootURL.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	LicenseURL  string `yaml:"license_url"`
 	Intro       string `yaml:"intro"`
 	DeployRepo  string `yaml:"deploy_repo"`
+	CachePath   string `yaml:"cache_path"`
 }
 
 // SiteRootPath returns the URL path component of SiteRootURL.
@@ -111,6 +112,7 @@ func Load(yamlPath string, flagOverrides map[string]string) (Config, error) {
 	// file is discarded here.
 	cfg.BuildPath = ""
 	cfg.StaticPath = ExpandPath(cfg.StaticPath)
+	cfg.CachePath = ExpandPath(cfg.CachePath)
 	if cfg.StaticPath == "" && cfg.NotesPath != "" {
 		cfg.StaticPath = filepath.Join(cfg.NotesPath, "static")
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -21,7 +21,6 @@ func TestLoadFromYAML(t *testing.T) {
 	yamlPath := writeConfig(t, `
 notes_path: "/tmp/notes"
 assets_path: "/tmp/assets"
-build_path: "./dist"
 site_root_url: "https://example.com"
 site_name: "Test Site"
 author_name: "Test Author"
@@ -32,7 +31,6 @@ author_name: "Test Author"
 
 	assert.Equal(t, "/tmp/notes", cfg.NotesPath)
 	assert.Equal(t, "/tmp/assets", cfg.AssetsPath)
-	assert.Equal(t, "./dist", cfg.BuildPath)
 	assert.Equal(t, "https://example.com", cfg.SiteRootURL)
 	assert.Equal(t, "Test Site", cfg.SiteName)
 	assert.Equal(t, "Test Author", cfg.AuthorName)
@@ -42,7 +40,6 @@ func TestFlagOverridesYAML(t *testing.T) {
 	yamlPath := writeConfig(t, `
 notes_path: "/tmp/notes"
 assets_path: "/tmp/assets"
-build_path: "./dist"
 site_root_url: "https://example.com"
 site_name: "Test Site"
 author_name: "Test Author"
@@ -66,7 +63,6 @@ notes_path: "/tmp/notes"
 func TestAssetsPathDefaultsToNotesImages(t *testing.T) {
 	yamlPath := writeConfig(t, `
 notes_path: "/tmp/notes"
-build_path: "./dist"
 site_root_url: "https://example.com"
 site_name: "Test Site"
 author_name: "Test Author"
@@ -78,9 +74,10 @@ author_name: "Test Author"
 	assert.Equal(t, filepath.Join("/tmp/notes", "images"), cfg.AssetsPath)
 }
 
-func TestBuildPathDefaultsToDist(t *testing.T) {
+func TestLoadIgnoresBuildPath(t *testing.T) {
 	yamlPath := writeConfig(t, `
 notes_path: "/tmp/notes"
+build_path: "/tmp/should-be-ignored"
 site_root_url: "https://example.com"
 site_name: "Test Site"
 author_name: "Test Author"
@@ -89,12 +86,11 @@ author_name: "Test Author"
 	cfg, err := Load(yamlPath, nil)
 	require.NoError(t, err)
 
-	assert.Equal(t, "./dist", cfg.BuildPath)
+	assert.Empty(t, cfg.BuildPath, "build_path is resolved by the caller, not loaded from YAML")
 }
 
 func TestNotesPathDefaultsToEnvVar(t *testing.T) {
 	yamlPath := writeConfig(t, `
-build_path: "./dist"
 site_root_url: "https://example.com"
 site_name: "Test Site"
 author_name: "Test Author"
@@ -111,7 +107,6 @@ func TestExpandHomePath(t *testing.T) {
 	yamlPath := writeConfig(t, `
 notes_path: "~/notes"
 assets_path: "~/assets"
-build_path: "./dist"
 site_root_url: "https://example.com"
 site_name: "Test Site"
 author_name: "Test Author"
@@ -129,7 +124,6 @@ func TestExpandEnvVarsInYAMLPaths(t *testing.T) {
 	yamlPath := writeConfig(t, `
 notes_path: "$NPUB_TEST_ROOT/notes"
 assets_path: "$NPUB_TEST_ROOT/assets"
-build_path: "$NPUB_TEST_ROOT/dist"
 static_path: "$NPUB_TEST_ROOT/static"
 site_root_url: "https://example.com"
 site_name: "Test Site"
@@ -142,7 +136,6 @@ author_name: "Test Author"
 
 	assert.Equal(t, "/srv/npub/notes", cfg.NotesPath)
 	assert.Equal(t, "/srv/npub/assets", cfg.AssetsPath)
-	assert.Equal(t, "/srv/npub/dist", cfg.BuildPath)
 	assert.Equal(t, "/srv/npub/static", cfg.StaticPath)
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -74,7 +74,9 @@ author_name: "Test Author"
 	assert.Equal(t, filepath.Join("/tmp/notes", "images"), cfg.AssetsPath)
 }
 
-func TestLoadIgnoresBuildPath(t *testing.T) {
+func TestLoadIgnoresLegacyBuildPath(t *testing.T) {
+	// build_path used to be a config key; existing files with it must still
+	// load without error. The YAML library silently ignores unknown keys.
 	yamlPath := writeConfig(t, `
 notes_path: "/tmp/notes"
 build_path: "/tmp/should-be-ignored"
@@ -83,10 +85,8 @@ site_name: "Test Site"
 author_name: "Test Author"
 `)
 
-	cfg, err := Load(yamlPath, nil)
+	_, err := Load(yamlPath, nil)
 	require.NoError(t, err)
-
-	assert.Empty(t, cfg.BuildPath, "build_path is resolved by the caller, not loaded from YAML")
 }
 
 func TestNotesPathDefaultsToEnvVar(t *testing.T) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -74,21 +74,6 @@ author_name: "Test Author"
 	assert.Equal(t, filepath.Join("/tmp/notes", "images"), cfg.AssetsPath)
 }
 
-func TestLoadIgnoresLegacyBuildPath(t *testing.T) {
-	// build_path used to be a config key; existing files with it must still
-	// load without error. The YAML library silently ignores unknown keys.
-	yamlPath := writeConfig(t, `
-notes_path: "/tmp/notes"
-build_path: "/tmp/should-be-ignored"
-site_root_url: "https://example.com"
-site_name: "Test Site"
-author_name: "Test Author"
-`)
-
-	_, err := Load(yamlPath, nil)
-	require.NoError(t, err)
-}
-
 func TestNotesPathDefaultsToEnvVar(t *testing.T) {
 	yamlPath := writeConfig(t, `
 site_root_url: "https://example.com"

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 )
 
-// CacheRoot returns the root directory used for deploy working copies.
+// CacheRoot returns the root directory used for deploy artifacts.
 func CacheRoot() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -22,8 +22,9 @@ func CacheRoot() (string, error) {
 	return filepath.Join(home, ".cache", "npub"), nil
 }
 
-// WorkDir returns the working directory for a given deploy repo URL.
-func WorkDir(repoURL string) (string, error) {
+// CacheDir returns the per-repo cache parent for repoURL,
+// ~/.cache/npub/<repo>. Both BuildDir and RepoDir live under it.
+func CacheDir(repoURL string) (string, error) {
 	if strings.TrimSpace(repoURL) == "" {
 		return "", errors.New("deploy_repo is empty")
 	}
@@ -36,6 +37,27 @@ func WorkDir(repoURL string) (string, error) {
 		return "", fmt.Errorf("cannot derive a directory name from deploy_repo %q", repoURL)
 	}
 	return filepath.Join(root, slug), nil
+}
+
+// BuildDir returns the directory where `npub build` writes the rendered site
+// for repoURL: ~/.cache/npub/<repo>/build. It is a plain directory, not a
+// git working copy.
+func BuildDir(repoURL string) (string, error) {
+	dir, err := CacheDir(repoURL)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "build"), nil
+}
+
+// RepoDir returns the directory where `npub deploy` keeps the git working
+// copy of repoURL: ~/.cache/npub/<repo>/repo.
+func RepoDir(repoURL string) (string, error) {
+	dir, err := CacheDir(repoURL)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "repo"), nil
 }
 
 // RepoSlug derives a directory name from a git repository URL. It strips a
@@ -72,8 +94,8 @@ func (o Options) writers() (io.Writer, io.Writer) {
 // Prepare ensures workDir contains an up-to-date checkout of repoURL. If
 // workDir does not exist, repoURL is cloned into it. Otherwise the remote
 // is verified, fetched, and the working copy is hard-reset to the remote
-// default branch, discarding local commits and untracked files so the next
-// build starts from a clean state.
+// default branch, discarding local commits and untracked files so a
+// subsequent Sync starts from a clean mirror of origin.
 func Prepare(repoURL, workDir string, opt Options) error {
 	if err := requireGit(); err != nil {
 		return err
@@ -158,6 +180,26 @@ func Push(workDir string, opt Options) error {
 	return nil
 }
 
+// IsSyncedWithOrigin reports whether HEAD points at the same commit as its
+// upstream tracking branch. Returns false when no upstream is configured
+// (e.g. a freshly-cloned repository whose default branch hasn't been pushed
+// since cloning), so callers treat that case as "needs a push".
+func IsSyncedWithOrigin(workDir string) (bool, error) {
+	upstream, err := gitOutput(workDir, "rev-parse", "--symbolic-full-name", "@{u}")
+	if err != nil || upstream == "" {
+		return false, nil
+	}
+	head, err := gitOutput(workDir, "rev-parse", "HEAD")
+	if err != nil {
+		return false, err
+	}
+	upstreamSHA, err := gitOutput(workDir, "rev-parse", upstream)
+	if err != nil {
+		return false, err
+	}
+	return head == upstreamSHA, nil
+}
+
 // DefaultBranch returns the name of the remote's default branch (e.g. "main"
 // or "master") as recorded in refs/remotes/origin/HEAD, falling back to the
 // currently checked-out local branch if the symbolic ref is absent (e.g. on
@@ -185,6 +227,84 @@ func DefaultBranch(workDir string) (string, error) {
 		return out, nil
 	}
 	return "", errors.New("could not determine default branch of origin (is the remote empty?)")
+}
+
+// Sync mirrors srcDir into destDir, preserving destDir/.git so the next
+// commit picks up the diff against the previously deployed state. Files in
+// destDir other than .git are removed before srcDir is copied in.
+func Sync(srcDir, destDir string) error {
+	srcInfo, err := os.Stat(srcDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("build directory %s does not exist; run `npub build` first", srcDir)
+		}
+		return fmt.Errorf("checking %s: %w", srcDir, err)
+	}
+	if !srcInfo.IsDir() {
+		return fmt.Errorf("build path %s is not a directory", srcDir)
+	}
+	if err := clearExceptGit(destDir); err != nil {
+		return err
+	}
+	return copyTree(srcDir, destDir)
+}
+
+// clearExceptGit removes every entry in destDir other than the .git
+// directory, so a subsequent copy yields a clean mirror.
+func clearExceptGit(destDir string) error {
+	entries, err := os.ReadDir(destDir)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", destDir, err)
+	}
+	for _, e := range entries {
+		if e.Name() == ".git" {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(destDir, e.Name())); err != nil {
+			return fmt.Errorf("removing %s: %w", e.Name(), err)
+		}
+	}
+	return nil
+}
+
+func copyTree(srcDir, destDir string) error {
+	return filepath.WalkDir(srcDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(srcDir, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		dest := filepath.Join(destDir, rel)
+		if d.IsDir() {
+			return os.MkdirAll(dest, 0o755)
+		}
+		return copyFile(path, dest)
+	})
+}
+
+func copyFile(src, dest string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = in.Close() }()
+	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+		return err
+	}
+	out, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
 }
 
 func verifyOrigin(workDir, repoURL string) error {

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -1,5 +1,8 @@
-// Package deploy manages a local working copy of the deploy target git
-// repository, where the built site is committed and pushed.
+// Package deploy publishes the built site to a git remote. It maintains a
+// bare clone of deploy_repo at ~/.cache/npub/<repo>/git and uses the build
+// output at ~/.cache/npub/<repo>/build as a temporary work-tree (via git's
+// --git-dir and --work-tree options) when committing. This avoids copying
+// the site into a separate working copy.
 package deploy
 
 import (
@@ -23,7 +26,7 @@ func CacheRoot() (string, error) {
 }
 
 // CacheDir returns the per-repo cache parent for repoURL,
-// ~/.cache/npub/<repo>. Both BuildDir and RepoDir live under it.
+// ~/.cache/npub/<repo>. BuildDir and GitDir live under it.
 func CacheDir(repoURL string) (string, error) {
 	if strings.TrimSpace(repoURL) == "" {
 		return "", errors.New("deploy_repo is empty")
@@ -39,9 +42,9 @@ func CacheDir(repoURL string) (string, error) {
 	return filepath.Join(root, slug), nil
 }
 
-// BuildDir returns the directory where `npub build` writes the rendered site
-// for repoURL: ~/.cache/npub/<repo>/build. It is a plain directory, not a
-// git working copy.
+// BuildDir returns the directory where `npub build` writes the rendered
+// site for repoURL: ~/.cache/npub/<repo>/build. It is a plain directory,
+// never a git working copy.
 func BuildDir(repoURL string) (string, error) {
 	dir, err := CacheDir(repoURL)
 	if err != nil {
@@ -50,14 +53,15 @@ func BuildDir(repoURL string) (string, error) {
 	return filepath.Join(dir, "build"), nil
 }
 
-// RepoDir returns the directory where `npub deploy` keeps the git working
-// copy of repoURL: ~/.cache/npub/<repo>/repo.
-func RepoDir(repoURL string) (string, error) {
+// GitDir returns the bare git directory for repoURL:
+// ~/.cache/npub/<repo>/git. `npub deploy` clones deploy_repo here on first
+// use and treats BuildDir as a temporary work-tree when committing.
+func GitDir(repoURL string) (string, error) {
 	dir, err := CacheDir(repoURL)
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(dir, "repo"), nil
+	return filepath.Join(dir, "git"), nil
 }
 
 // RepoSlug derives a directory name from a git repository URL. It strips a
@@ -91,231 +95,138 @@ func (o Options) writers() (io.Writer, io.Writer) {
 	return out, errw
 }
 
-// Prepare ensures workDir contains an up-to-date checkout of repoURL. If
-// workDir does not exist, repoURL is cloned into it. Otherwise the remote
-// is verified, fetched, and the working copy is hard-reset to the remote
-// default branch, discarding local commits and untracked files so a
-// subsequent Sync starts from a clean mirror of origin.
-func Prepare(repoURL, workDir string, opt Options) error {
+// Prepare ensures gitDir is a clone of repoURL and resets HEAD + index to
+// origin's default branch tip without touching buildDir's contents. On
+// first use it runs `git clone --bare`; on subsequent runs it fetches and
+// resets. After Prepare returns, the bare repository's index reflects
+// origin's last published state, so a subsequent `git add -A` against
+// buildDir stages exactly the diff that needs to be committed.
+func Prepare(repoURL, gitDir, buildDir string, opt Options) error {
 	if err := requireGit(); err != nil {
 		return err
 	}
 	stdout, stderr := opt.writers()
-	info, err := os.Stat(workDir)
+
+	info, err := os.Stat(buildDir)
 	if err != nil {
-		if !os.IsNotExist(err) {
-			return fmt.Errorf("checking %s: %w", workDir, err)
+		if os.IsNotExist(err) {
+			return fmt.Errorf("build directory %s does not exist; run `npub build` first", buildDir)
 		}
-		if err := os.MkdirAll(filepath.Dir(workDir), 0o755); err != nil {
-			return fmt.Errorf("creating cache parent %s: %w", filepath.Dir(workDir), err)
-		}
-		if err := runGit(stdout, stderr, "", "clone", repoURL, workDir); err != nil {
-			_ = os.RemoveAll(workDir)
-			return fmt.Errorf("cloning %s: %w", repoURL, err)
-		}
-		return nil
+		return fmt.Errorf("checking %s: %w", buildDir, err)
 	}
 	if !info.IsDir() {
-		return fmt.Errorf("deploy cache path %s exists but is not a directory; remove it and rerun", workDir)
+		return fmt.Errorf("build path %s is not a directory", buildDir)
 	}
-	if _, err := os.Stat(filepath.Join(workDir, ".git")); err != nil {
-		return fmt.Errorf("deploy cache %s is not a git working copy; remove it and rerun", workDir)
+
+	if _, err := os.Stat(gitDir); err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("checking %s: %w", gitDir, err)
+		}
+		if err := os.MkdirAll(filepath.Dir(gitDir), 0o755); err != nil {
+			return fmt.Errorf("creating cache parent %s: %w", filepath.Dir(gitDir), err)
+		}
+		if err := runGit(stdout, stderr, "", "clone", "--bare", repoURL, gitDir); err != nil {
+			_ = os.RemoveAll(gitDir)
+			return fmt.Errorf("cloning %s: %w", repoURL, err)
+		}
+		// `git clone --bare` sets up the origin remote but no fetch refspec
+		// and no refs/remotes/origin/*. Add the standard refspec so future
+		// fetches mirror origin into refs/remotes/origin/*, which lets us
+		// distinguish origin's tip from our locally-committed branch.
+		if err := runGit(stdout, stderr, "", "--git-dir="+gitDir, "config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*"); err != nil {
+			return err
+		}
+		// Disable bareness so add/commit will operate on --work-tree without
+		// refusing.
+		if err := runGit(stdout, stderr, "", "--git-dir="+gitDir, "config", "core.bare", "false"); err != nil {
+			return err
+		}
+	} else {
+		if err := verifyOrigin(gitDir, repoURL); err != nil {
+			return err
+		}
 	}
-	if err := verifyOrigin(workDir, repoURL); err != nil {
-		return err
-	}
-	if err := runGit(stdout, stderr, workDir, "fetch", "--prune", "origin"); err != nil {
+
+	if err := runGit(stdout, stderr, "", "--git-dir="+gitDir, "fetch", "--prune", "origin"); err != nil {
 		return fmt.Errorf("fetching %s: %w", repoURL, err)
 	}
-	branch, err := DefaultBranch(workDir)
+
+	branch, err := DefaultBranch(gitDir)
 	if err != nil {
 		return err
 	}
-	if err := runGit(stdout, stderr, workDir, "checkout", branch); err != nil {
-		return fmt.Errorf("checking out %s: %w", branch, err)
-	}
-	if err := runGit(stdout, stderr, workDir, "reset", "--hard", "origin/"+branch); err != nil {
+	// reset --mixed updates HEAD and the index, but leaves the work-tree
+	// (buildDir) alone so the next `git add -A` sees exactly the difference
+	// between origin and the build output.
+	if err := runGit(stdout, stderr, "", "--git-dir="+gitDir, "--work-tree="+buildDir,
+		"reset", "--mixed", "origin/"+branch); err != nil {
 		return fmt.Errorf("resetting to origin/%s: %w", branch, err)
-	}
-	if err := runGit(stdout, stderr, workDir, "clean", "-fd"); err != nil {
-		return fmt.Errorf("cleaning %s: %w", workDir, err)
 	}
 	return nil
 }
 
-// Commit stages all changes in workDir and creates a commit with the given
-// message. Returns true if a commit was created, false if there was nothing
-// to commit.
-func Commit(workDir, message string, opt Options) (bool, error) {
+// Commit stages every change between origin and buildDir, then commits if
+// anything is staged. Returns true when a commit was created.
+func Commit(gitDir, buildDir, message string, opt Options) (bool, error) {
 	if err := requireGit(); err != nil {
 		return false, err
 	}
 	stdout, stderr := opt.writers()
-	if err := runGit(stdout, stderr, workDir, "add", "-A"); err != nil {
+	if err := runGit(stdout, stderr, "", "--git-dir="+gitDir, "--work-tree="+buildDir, "add", "-A"); err != nil {
 		return false, fmt.Errorf("staging changes: %w", err)
 	}
-	clean, err := isClean(workDir)
+	out, err := gitOutput("", "--git-dir="+gitDir, "--work-tree="+buildDir, "status", "--porcelain")
 	if err != nil {
-		return false, fmt.Errorf("checking working tree status: %w", err)
+		return false, fmt.Errorf("checking status: %w", err)
 	}
-	if clean {
+	if out == "" {
 		return false, nil
 	}
-	if err := runGit(stdout, stderr, workDir, "commit", "-m", message); err != nil {
+	if err := runGit(stdout, stderr, "", "--git-dir="+gitDir, "--work-tree="+buildDir, "commit", "-m", message); err != nil {
 		return false, fmt.Errorf("creating commit: %w", err)
 	}
 	return true, nil
 }
 
-// Push pushes the current branch in workDir to origin, setting upstream so
-// that the first push against a previously-empty repository succeeds.
-func Push(workDir string, opt Options) error {
+// Push pushes HEAD to origin, setting upstream so the first push against a
+// previously-empty repository succeeds.
+func Push(gitDir string, opt Options) error {
 	if err := requireGit(); err != nil {
 		return err
 	}
 	stdout, stderr := opt.writers()
-	if err := runGit(stdout, stderr, workDir, "push", "--set-upstream", "origin", "HEAD"); err != nil {
+	if err := runGit(stdout, stderr, "", "--git-dir="+gitDir, "push", "--set-upstream", "origin", "HEAD"); err != nil {
 		return fmt.Errorf("pushing to origin: %w", err)
 	}
 	return nil
 }
 
-// IsSyncedWithOrigin reports whether HEAD points at the same commit as its
-// upstream tracking branch. Returns false when no upstream is configured
-// (e.g. a freshly-cloned repository whose default branch hasn't been pushed
-// since cloning), so callers treat that case as "needs a push".
-func IsSyncedWithOrigin(workDir string) (bool, error) {
-	upstream, err := gitOutput(workDir, "rev-parse", "--symbolic-full-name", "@{u}")
-	if err != nil || upstream == "" {
-		return false, nil
+// DefaultBranch returns the name of the default branch tracked by gitDir.
+// `git clone --bare` initializes HEAD as a symref to refs/heads/<default>,
+// so the local symref tells us the branch name without an extra round-trip
+// to the remote.
+func DefaultBranch(gitDir string) (string, error) {
+	if out, err := gitOutput("", "--git-dir="+gitDir, "symbolic-ref", "--short", "HEAD"); err == nil && out != "" {
+		return out, nil
 	}
-	head, err := gitOutput(workDir, "rev-parse", "HEAD")
-	if err != nil {
-		return false, err
-	}
-	upstreamSHA, err := gitOutput(workDir, "rev-parse", upstream)
-	if err != nil {
-		return false, err
-	}
-	return head == upstreamSHA, nil
-}
-
-// DefaultBranch returns the name of the remote's default branch (e.g. "main"
-// or "master") as recorded in refs/remotes/origin/HEAD, falling back to the
-// currently checked-out local branch if the symbolic ref is absent (e.g. on
-// a freshly-cloned empty repository).
-func DefaultBranch(workDir string) (string, error) {
-	if out, err := gitOutput(workDir, "symbolic-ref", "--short", "refs/remotes/origin/HEAD"); err == nil {
-		// Returns e.g. "origin/main".
+	if out, err := gitOutput("", "--git-dir="+gitDir, "symbolic-ref", "--short", "refs/remotes/origin/HEAD"); err == nil {
 		if i := strings.IndexByte(out, '/'); i >= 0 {
 			return out[i+1:], nil
 		}
 		return out, nil
 	}
-	if out, err := gitOutput(workDir, "remote", "show", "origin"); err == nil {
-		for _, line := range strings.Split(out, "\n") {
-			line = strings.TrimSpace(line)
-			if rest, ok := strings.CutPrefix(line, "HEAD branch:"); ok {
-				name := strings.TrimSpace(rest)
-				if name != "" && name != "(unknown)" {
-					return name, nil
-				}
-			}
-		}
-	}
-	if out, err := gitOutput(workDir, "symbolic-ref", "--short", "HEAD"); err == nil && out != "" {
-		return out, nil
-	}
-	return "", errors.New("could not determine default branch of origin (is the remote empty?)")
+	return "", errors.New("could not determine default branch (is the remote empty?)")
 }
 
-// Sync mirrors srcDir into destDir, preserving destDir/.git so the next
-// commit picks up the diff against the previously deployed state. Files in
-// destDir other than .git are removed before srcDir is copied in.
-func Sync(srcDir, destDir string) error {
-	srcInfo, err := os.Stat(srcDir)
+func verifyOrigin(gitDir, repoURL string) error {
+	got, err := gitOutput("", "--git-dir="+gitDir, "remote", "get-url", "origin")
 	if err != nil {
-		if os.IsNotExist(err) {
-			return fmt.Errorf("build directory %s does not exist; run `npub build` first", srcDir)
-		}
-		return fmt.Errorf("checking %s: %w", srcDir, err)
-	}
-	if !srcInfo.IsDir() {
-		return fmt.Errorf("build path %s is not a directory", srcDir)
-	}
-	if err := clearExceptGit(destDir); err != nil {
-		return err
-	}
-	return copyTree(srcDir, destDir)
-}
-
-// clearExceptGit removes every entry in destDir other than the .git
-// directory, so a subsequent copy yields a clean mirror.
-func clearExceptGit(destDir string) error {
-	entries, err := os.ReadDir(destDir)
-	if err != nil {
-		return fmt.Errorf("reading %s: %w", destDir, err)
-	}
-	for _, e := range entries {
-		if e.Name() == ".git" {
-			continue
-		}
-		if err := os.RemoveAll(filepath.Join(destDir, e.Name())); err != nil {
-			return fmt.Errorf("removing %s: %w", e.Name(), err)
-		}
-	}
-	return nil
-}
-
-func copyTree(srcDir, destDir string) error {
-	return filepath.WalkDir(srcDir, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		rel, err := filepath.Rel(srcDir, path)
-		if err != nil {
-			return err
-		}
-		if rel == "." {
-			return nil
-		}
-		dest := filepath.Join(destDir, rel)
-		if d.IsDir() {
-			return os.MkdirAll(dest, 0o755)
-		}
-		return copyFile(path, dest)
-	})
-}
-
-func copyFile(src, dest string) error {
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = in.Close() }()
-	if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
-		return err
-	}
-	out, err := os.Create(dest)
-	if err != nil {
-		return err
-	}
-	if _, err := io.Copy(out, in); err != nil {
-		_ = out.Close()
-		return err
-	}
-	return out.Close()
-}
-
-func verifyOrigin(workDir, repoURL string) error {
-	got, err := gitOutput(workDir, "remote", "get-url", "origin")
-	if err != nil {
-		return fmt.Errorf("reading origin URL of %s: %w", workDir, err)
+		return fmt.Errorf("reading origin URL of %s: %w", gitDir, err)
 	}
 	if got != repoURL {
 		return fmt.Errorf(
 			"deploy cache %s tracks %s but deploy_repo is %s; remove the cache directory or revert deploy_repo",
-			workDir, got, repoURL,
+			gitDir, got, repoURL,
 		)
 	}
 	return nil
@@ -373,12 +284,4 @@ func lastNonEmptyLine(s string) string {
 		}
 	}
 	return ""
-}
-
-func isClean(dir string) (bool, error) {
-	out, err := gitOutput(dir, "status", "--porcelain")
-	if err != nil {
-		return false, err
-	}
-	return out == "", nil
 }

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -17,20 +17,23 @@ import (
 func CacheRoot() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("cannot determine home directory: %w", err)
 	}
 	return filepath.Join(home, ".cache", "npub"), nil
 }
 
 // WorkDir returns the working directory for a given deploy repo URL.
 func WorkDir(repoURL string) (string, error) {
+	if strings.TrimSpace(repoURL) == "" {
+		return "", errors.New("deploy_repo is empty")
+	}
 	root, err := CacheRoot()
 	if err != nil {
 		return "", err
 	}
 	slug := RepoSlug(repoURL)
 	if slug == "" {
-		return "", fmt.Errorf("cannot derive directory name from %q", repoURL)
+		return "", fmt.Errorf("cannot derive a directory name from deploy_repo %q", repoURL)
 	}
 	return filepath.Join(root, slug), nil
 }
@@ -68,72 +71,97 @@ func (o Options) writers() (io.Writer, io.Writer) {
 
 // Prepare ensures workDir contains an up-to-date checkout of repoURL. If
 // workDir does not exist, repoURL is cloned into it. Otherwise the remote
-// is fetched and the working copy is hard-reset to the remote default
-// branch, discarding local commits and untracked files so the next build
-// starts from a clean state.
+// is verified, fetched, and the working copy is hard-reset to the remote
+// default branch, discarding local commits and untracked files so the next
+// build starts from a clean state.
 func Prepare(repoURL, workDir string, opt Options) error {
+	if err := requireGit(); err != nil {
+		return err
+	}
 	stdout, stderr := opt.writers()
 	info, err := os.Stat(workDir)
 	if err != nil {
 		if !os.IsNotExist(err) {
-			return err
+			return fmt.Errorf("checking %s: %w", workDir, err)
 		}
 		if err := os.MkdirAll(filepath.Dir(workDir), 0o755); err != nil {
-			return fmt.Errorf("creating cache parent: %w", err)
+			return fmt.Errorf("creating cache parent %s: %w", filepath.Dir(workDir), err)
 		}
-		return runGit(stdout, stderr, "", "clone", repoURL, workDir)
+		if err := runGit(stdout, stderr, "", "clone", repoURL, workDir); err != nil {
+			_ = os.RemoveAll(workDir)
+			return fmt.Errorf("cloning %s: %w", repoURL, err)
+		}
+		return nil
 	}
 	if !info.IsDir() {
-		return fmt.Errorf("not a directory: %s", workDir)
+		return fmt.Errorf("deploy cache path %s exists but is not a directory; remove it and rerun", workDir)
 	}
 	if _, err := os.Stat(filepath.Join(workDir, ".git")); err != nil {
-		return fmt.Errorf("not a git working copy: %s", workDir)
+		return fmt.Errorf("deploy cache %s is not a git working copy; remove it and rerun", workDir)
+	}
+	if err := verifyOrigin(workDir, repoURL); err != nil {
+		return err
 	}
 	if err := runGit(stdout, stderr, workDir, "fetch", "--prune", "origin"); err != nil {
-		return err
+		return fmt.Errorf("fetching %s: %w", repoURL, err)
 	}
 	branch, err := DefaultBranch(workDir)
 	if err != nil {
 		return err
 	}
 	if err := runGit(stdout, stderr, workDir, "checkout", branch); err != nil {
-		return err
+		return fmt.Errorf("checking out %s: %w", branch, err)
 	}
 	if err := runGit(stdout, stderr, workDir, "reset", "--hard", "origin/"+branch); err != nil {
-		return err
+		return fmt.Errorf("resetting to origin/%s: %w", branch, err)
 	}
-	return runGit(stdout, stderr, workDir, "clean", "-fd")
+	if err := runGit(stdout, stderr, workDir, "clean", "-fd"); err != nil {
+		return fmt.Errorf("cleaning %s: %w", workDir, err)
+	}
+	return nil
 }
 
 // Commit stages all changes in workDir and creates a commit with the given
 // message. Returns true if a commit was created, false if there was nothing
 // to commit.
 func Commit(workDir, message string, opt Options) (bool, error) {
+	if err := requireGit(); err != nil {
+		return false, err
+	}
 	stdout, stderr := opt.writers()
 	if err := runGit(stdout, stderr, workDir, "add", "-A"); err != nil {
-		return false, err
+		return false, fmt.Errorf("staging changes: %w", err)
 	}
 	clean, err := isClean(workDir)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("checking working tree status: %w", err)
 	}
 	if clean {
 		return false, nil
 	}
 	if err := runGit(stdout, stderr, workDir, "commit", "-m", message); err != nil {
-		return false, err
+		return false, fmt.Errorf("creating commit: %w", err)
 	}
 	return true, nil
 }
 
-// Push pushes the current branch in workDir to its upstream.
+// Push pushes the current branch in workDir to origin, setting upstream so
+// that the first push against a previously-empty repository succeeds.
 func Push(workDir string, opt Options) error {
+	if err := requireGit(); err != nil {
+		return err
+	}
 	stdout, stderr := opt.writers()
-	return runGit(stdout, stderr, workDir, "push")
+	if err := runGit(stdout, stderr, workDir, "push", "--set-upstream", "origin", "HEAD"); err != nil {
+		return fmt.Errorf("pushing to origin: %w", err)
+	}
+	return nil
 }
 
 // DefaultBranch returns the name of the remote's default branch (e.g. "main"
-// or "master") as recorded in refs/remotes/origin/HEAD.
+// or "master") as recorded in refs/remotes/origin/HEAD, falling back to the
+// currently checked-out local branch if the symbolic ref is absent (e.g. on
+// a freshly-cloned empty repository).
 func DefaultBranch(workDir string) (string, error) {
 	if out, err := gitOutput(workDir, "symbolic-ref", "--short", "refs/remotes/origin/HEAD"); err == nil {
 		// Returns e.g. "origin/main".
@@ -142,27 +170,59 @@ func DefaultBranch(workDir string) (string, error) {
 		}
 		return out, nil
 	}
-	out, err := gitOutput(workDir, "remote", "show", "origin")
-	if err != nil {
-		return "", fmt.Errorf("determining default branch: %w", err)
-	}
-	for _, line := range strings.Split(out, "\n") {
-		line = strings.TrimSpace(line)
-		if rest, ok := strings.CutPrefix(line, "HEAD branch:"); ok {
-			return strings.TrimSpace(rest), nil
+	if out, err := gitOutput(workDir, "remote", "show", "origin"); err == nil {
+		for _, line := range strings.Split(out, "\n") {
+			line = strings.TrimSpace(line)
+			if rest, ok := strings.CutPrefix(line, "HEAD branch:"); ok {
+				name := strings.TrimSpace(rest)
+				if name != "" && name != "(unknown)" {
+					return name, nil
+				}
+			}
 		}
 	}
-	return "", errors.New("could not determine default branch")
+	if out, err := gitOutput(workDir, "symbolic-ref", "--short", "HEAD"); err == nil && out != "" {
+		return out, nil
+	}
+	return "", errors.New("could not determine default branch of origin (is the remote empty?)")
 }
 
+func verifyOrigin(workDir, repoURL string) error {
+	got, err := gitOutput(workDir, "remote", "get-url", "origin")
+	if err != nil {
+		return fmt.Errorf("reading origin URL of %s: %w", workDir, err)
+	}
+	if got != repoURL {
+		return fmt.Errorf(
+			"deploy cache %s tracks %s but deploy_repo is %s; remove the cache directory or revert deploy_repo",
+			workDir, got, repoURL,
+		)
+	}
+	return nil
+}
+
+func requireGit() error {
+	if _, err := exec.LookPath("git"); err != nil {
+		return errors.New("git executable not found in PATH; install git to use npub deploy")
+	}
+	return nil
+}
+
+// runGit executes git, streaming output to the caller's stdout/stderr while
+// also capturing stderr so the returned error includes git's own message
+// instead of a bare "exit status N".
 func runGit(stdout, stderr io.Writer, dir string, args ...string) error {
+	var errBuf bytes.Buffer
 	cmd := exec.Command("git", args...)
 	if dir != "" {
 		cmd.Dir = dir
 	}
 	cmd.Stdout = stdout
-	cmd.Stderr = stderr
+	cmd.Stderr = io.MultiWriter(stderr, &errBuf)
 	if err := cmd.Run(); err != nil {
+		if msg := lastNonEmptyLine(errBuf.String()); msg != "" {
+			return fmt.Errorf("git %s: %s", strings.Join(args, " "), msg)
+		}
 		return fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
 	}
 	return nil
@@ -177,9 +237,22 @@ func gitOutput(dir string, args ...string) (string, error) {
 	cmd.Stdout = &out
 	cmd.Stderr = &errBuf
 	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("git %s: %w (%s)", strings.Join(args, " "), err, strings.TrimSpace(errBuf.String()))
+		if msg := lastNonEmptyLine(errBuf.String()); msg != "" {
+			return "", fmt.Errorf("git %s: %s", strings.Join(args, " "), msg)
+		}
+		return "", fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
 	}
 	return strings.TrimSpace(out.String()), nil
+}
+
+func lastNonEmptyLine(s string) string {
+	lines := strings.Split(strings.TrimRight(s, "\n"), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if line := strings.TrimSpace(lines[i]); line != "" {
+			return line
+		}
+	}
+	return ""
 }
 
 func isClean(dir string) (bool, error) {

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -25,9 +25,10 @@ func CacheRoot() (string, error) {
 	return filepath.Join(home, ".cache", "npub"), nil
 }
 
-// CacheDir returns the per-repo cache parent for repoURL,
-// ~/.cache/npub/<repo>. BuildDir and GitDir live under it.
-func CacheDir(repoURL string) (string, error) {
+// DefaultCacheDir returns the conventional per-repo cache directory for
+// repoURL, ~/.cache/npub/<repo>. Callers may pass any directory to BuildDir
+// and GitDir; this is just the default when no override is configured.
+func DefaultCacheDir(repoURL string) (string, error) {
 	if strings.TrimSpace(repoURL) == "" {
 		return "", errors.New("deploy_repo is empty")
 	}
@@ -42,26 +43,17 @@ func CacheDir(repoURL string) (string, error) {
 	return filepath.Join(root, slug), nil
 }
 
-// BuildDir returns the directory where `npub build` writes the rendered
-// site for repoURL: ~/.cache/npub/<repo>/build. It is a plain directory,
-// never a git working copy.
-func BuildDir(repoURL string) (string, error) {
-	dir, err := CacheDir(repoURL)
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, "build"), nil
+// BuildDir returns the build subdirectory of cacheDir, where `npub build`
+// writes the rendered site. cacheDir is the per-site cache directory
+// resolved by the caller.
+func BuildDir(cacheDir string) string {
+	return filepath.Join(cacheDir, "build")
 }
 
-// GitDir returns the bare git directory for repoURL:
-// ~/.cache/npub/<repo>/git. `npub deploy` clones deploy_repo here on first
-// use and treats BuildDir as a temporary work-tree when committing.
-func GitDir(repoURL string) (string, error) {
-	dir, err := CacheDir(repoURL)
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(dir, "git"), nil
+// GitDir returns the bare git subdirectory of cacheDir, where `npub deploy`
+// clones deploy_repo on first use.
+func GitDir(cacheDir string) string {
+	return filepath.Join(cacheDir, "git")
 }
 
 // RepoSlug derives a directory name from a git repository URL. It strips a

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -1,0 +1,191 @@
+// Package deploy manages a local working copy of the deploy target git
+// repository, where the built site is committed and pushed.
+package deploy
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// CacheRoot returns the root directory used for deploy working copies.
+func CacheRoot() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".cache", "npub"), nil
+}
+
+// WorkDir returns the working directory for a given deploy repo URL.
+func WorkDir(repoURL string) (string, error) {
+	root, err := CacheRoot()
+	if err != nil {
+		return "", err
+	}
+	slug := RepoSlug(repoURL)
+	if slug == "" {
+		return "", fmt.Errorf("cannot derive directory name from %q", repoURL)
+	}
+	return filepath.Join(root, slug), nil
+}
+
+// RepoSlug derives a directory name from a git repository URL. It strips a
+// trailing ".git" and returns the final path component, suitable as a local
+// directory name.
+func RepoSlug(repoURL string) string {
+	s := strings.TrimSpace(repoURL)
+	s = strings.TrimRight(s, "/")
+	s = strings.TrimSuffix(s, ".git")
+	if i := strings.LastIndexAny(s, "/:"); i >= 0 {
+		s = s[i+1:]
+	}
+	return s
+}
+
+// Options controls Prepare, Commit, and Push.
+type Options struct {
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+func (o Options) writers() (io.Writer, io.Writer) {
+	out := o.Stdout
+	if out == nil {
+		out = os.Stdout
+	}
+	errw := o.Stderr
+	if errw == nil {
+		errw = os.Stderr
+	}
+	return out, errw
+}
+
+// Prepare ensures workDir contains an up-to-date checkout of repoURL. If
+// workDir does not exist, repoURL is cloned into it. Otherwise the remote
+// is fetched and the working copy is hard-reset to the remote default
+// branch, discarding local commits and untracked files so the next build
+// starts from a clean state.
+func Prepare(repoURL, workDir string, opt Options) error {
+	stdout, stderr := opt.writers()
+	info, err := os.Stat(workDir)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return err
+		}
+		if err := os.MkdirAll(filepath.Dir(workDir), 0o755); err != nil {
+			return fmt.Errorf("creating cache parent: %w", err)
+		}
+		return runGit(stdout, stderr, "", "clone", repoURL, workDir)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("not a directory: %s", workDir)
+	}
+	if _, err := os.Stat(filepath.Join(workDir, ".git")); err != nil {
+		return fmt.Errorf("not a git working copy: %s", workDir)
+	}
+	if err := runGit(stdout, stderr, workDir, "fetch", "--prune", "origin"); err != nil {
+		return err
+	}
+	branch, err := DefaultBranch(workDir)
+	if err != nil {
+		return err
+	}
+	if err := runGit(stdout, stderr, workDir, "checkout", branch); err != nil {
+		return err
+	}
+	if err := runGit(stdout, stderr, workDir, "reset", "--hard", "origin/"+branch); err != nil {
+		return err
+	}
+	return runGit(stdout, stderr, workDir, "clean", "-fd")
+}
+
+// Commit stages all changes in workDir and creates a commit with the given
+// message. Returns true if a commit was created, false if there was nothing
+// to commit.
+func Commit(workDir, message string, opt Options) (bool, error) {
+	stdout, stderr := opt.writers()
+	if err := runGit(stdout, stderr, workDir, "add", "-A"); err != nil {
+		return false, err
+	}
+	clean, err := isClean(workDir)
+	if err != nil {
+		return false, err
+	}
+	if clean {
+		return false, nil
+	}
+	if err := runGit(stdout, stderr, workDir, "commit", "-m", message); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// Push pushes the current branch in workDir to its upstream.
+func Push(workDir string, opt Options) error {
+	stdout, stderr := opt.writers()
+	return runGit(stdout, stderr, workDir, "push")
+}
+
+// DefaultBranch returns the name of the remote's default branch (e.g. "main"
+// or "master") as recorded in refs/remotes/origin/HEAD.
+func DefaultBranch(workDir string) (string, error) {
+	if out, err := gitOutput(workDir, "symbolic-ref", "--short", "refs/remotes/origin/HEAD"); err == nil {
+		// Returns e.g. "origin/main".
+		if i := strings.IndexByte(out, '/'); i >= 0 {
+			return out[i+1:], nil
+		}
+		return out, nil
+	}
+	out, err := gitOutput(workDir, "remote", "show", "origin")
+	if err != nil {
+		return "", fmt.Errorf("determining default branch: %w", err)
+	}
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if rest, ok := strings.CutPrefix(line, "HEAD branch:"); ok {
+			return strings.TrimSpace(rest), nil
+		}
+	}
+	return "", errors.New("could not determine default branch")
+}
+
+func runGit(stdout, stderr io.Writer, dir string, args ...string) error {
+	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+	}
+	return nil
+}
+
+func gitOutput(dir string, args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	var out, errBuf bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errBuf
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("git %s: %w (%s)", strings.Join(args, " "), err, strings.TrimSpace(errBuf.String()))
+	}
+	return strings.TrimSpace(out.String()), nil
+}
+
+func isClean(dir string) (bool, error) {
+	out, err := gitOutput(dir, "status", "--porcelain")
+	if err != nil {
+		return false, err
+	}
+	return out == "", nil
+}

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -109,6 +109,17 @@ func Prepare(repoURL, gitDir, buildDir string, opt Options) error {
 	if !info.IsDir() {
 		return fmt.Errorf("build path %s is not a directory", buildDir)
 	}
+	// Refuse to deploy from an empty build directory: with a clean tree
+	// reset to origin's last published state, `git add -A` would stage a
+	// deletion of every file in origin and commit a wipe-out. Force the
+	// user to rebuild instead.
+	empty, err := dirHasNoContent(buildDir)
+	if err != nil {
+		return err
+	}
+	if empty {
+		return fmt.Errorf("build directory %s is empty; run `npub build` first", buildDir)
+	}
 
 	if _, err := os.Stat(gitDir); err != nil {
 		if !os.IsNotExist(err) {
@@ -266,6 +277,21 @@ func gitOutput(dir string, args ...string) (string, error) {
 		return "", fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
 	}
 	return strings.TrimSpace(out.String()), nil
+}
+
+// dirHasNoContent reports whether dir contains no entries other than
+// dotfiles. Returns true for a directory that is fully empty too.
+func dirHasNoContent(dir string) (bool, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false, fmt.Errorf("reading %s: %w", dir, err)
+	}
+	for _, e := range entries {
+		if !strings.HasPrefix(e.Name(), ".") {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 func lastNonEmptyLine(s string) string {

--- a/internal/deploy/deploy_test.go
+++ b/internal/deploy/deploy_test.go
@@ -1,7 +1,6 @@
 package deploy
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -32,52 +31,10 @@ func TestRepoSlug(t *testing.T) {
 func TestCacheLayout(t *testing.T) {
 	build, err := BuildDir("https://github.com/user/site.git")
 	require.NoError(t, err)
-	repo, err := RepoDir("https://github.com/user/site.git")
+	gitDir, err := GitDir("https://github.com/user/site.git")
 	require.NoError(t, err)
-	assert.Equal(t, filepath.Dir(build), filepath.Dir(repo), "build and repo share a parent")
+	assert.Equal(t, filepath.Dir(build), filepath.Dir(gitDir), "build and git share a parent")
 	assert.Equal(t, "build", filepath.Base(build))
-	assert.Equal(t, "repo", filepath.Base(repo))
+	assert.Equal(t, "git", filepath.Base(gitDir))
 	assert.Equal(t, "site", filepath.Base(filepath.Dir(build)))
-}
-
-func TestSyncMirrorsBuildIntoRepoPreservingGit(t *testing.T) {
-	root := t.TempDir()
-	src := filepath.Join(root, "build")
-	dst := filepath.Join(root, "repo")
-	require.NoError(t, os.MkdirAll(filepath.Join(src, "sub"), 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(src, "index.html"), []byte("new"), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(src, "sub", "page.html"), []byte("p"), 0o644))
-
-	require.NoError(t, os.MkdirAll(filepath.Join(dst, ".git", "objects"), 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(dst, ".git", "config"), []byte("git"), 0o644))
-	require.NoError(t, os.WriteFile(filepath.Join(dst, "stale.html"), []byte("old"), 0o644))
-	require.NoError(t, os.MkdirAll(filepath.Join(dst, "stale-dir"), 0o755))
-
-	require.NoError(t, Sync(src, dst))
-
-	// .git survives.
-	_, err := os.Stat(filepath.Join(dst, ".git", "config"))
-	assert.NoError(t, err, ".git/config should be preserved")
-
-	// New files copied.
-	got, err := os.ReadFile(filepath.Join(dst, "index.html"))
-	require.NoError(t, err)
-	assert.Equal(t, "new", string(got))
-	_, err = os.Stat(filepath.Join(dst, "sub", "page.html"))
-	assert.NoError(t, err)
-
-	// Stale entries gone.
-	_, err = os.Stat(filepath.Join(dst, "stale.html"))
-	assert.True(t, os.IsNotExist(err), "stale file should be removed")
-	_, err = os.Stat(filepath.Join(dst, "stale-dir"))
-	assert.True(t, os.IsNotExist(err), "stale dir should be removed")
-}
-
-func TestSyncErrorsWhenSourceMissing(t *testing.T) {
-	root := t.TempDir()
-	dst := filepath.Join(root, "repo")
-	require.NoError(t, os.MkdirAll(dst, 0o755))
-	err := Sync(filepath.Join(root, "missing"), dst)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "run `npub build` first")
 }

--- a/internal/deploy/deploy_test.go
+++ b/internal/deploy/deploy_test.go
@@ -1,9 +1,12 @@
 package deploy
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRepoSlug(t *testing.T) {
@@ -24,4 +27,57 @@ func TestRepoSlug(t *testing.T) {
 			assert.Equal(t, tt.want, RepoSlug(tt.in))
 		})
 	}
+}
+
+func TestCacheLayout(t *testing.T) {
+	build, err := BuildDir("https://github.com/user/site.git")
+	require.NoError(t, err)
+	repo, err := RepoDir("https://github.com/user/site.git")
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Dir(build), filepath.Dir(repo), "build and repo share a parent")
+	assert.Equal(t, "build", filepath.Base(build))
+	assert.Equal(t, "repo", filepath.Base(repo))
+	assert.Equal(t, "site", filepath.Base(filepath.Dir(build)))
+}
+
+func TestSyncMirrorsBuildIntoRepoPreservingGit(t *testing.T) {
+	root := t.TempDir()
+	src := filepath.Join(root, "build")
+	dst := filepath.Join(root, "repo")
+	require.NoError(t, os.MkdirAll(filepath.Join(src, "sub"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "index.html"), []byte("new"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "sub", "page.html"), []byte("p"), 0o644))
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dst, ".git", "objects"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dst, ".git", "config"), []byte("git"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dst, "stale.html"), []byte("old"), 0o644))
+	require.NoError(t, os.MkdirAll(filepath.Join(dst, "stale-dir"), 0o755))
+
+	require.NoError(t, Sync(src, dst))
+
+	// .git survives.
+	_, err := os.Stat(filepath.Join(dst, ".git", "config"))
+	assert.NoError(t, err, ".git/config should be preserved")
+
+	// New files copied.
+	got, err := os.ReadFile(filepath.Join(dst, "index.html"))
+	require.NoError(t, err)
+	assert.Equal(t, "new", string(got))
+	_, err = os.Stat(filepath.Join(dst, "sub", "page.html"))
+	assert.NoError(t, err)
+
+	// Stale entries gone.
+	_, err = os.Stat(filepath.Join(dst, "stale.html"))
+	assert.True(t, os.IsNotExist(err), "stale file should be removed")
+	_, err = os.Stat(filepath.Join(dst, "stale-dir"))
+	assert.True(t, os.IsNotExist(err), "stale dir should be removed")
+}
+
+func TestSyncErrorsWhenSourceMissing(t *testing.T) {
+	root := t.TempDir()
+	dst := filepath.Join(root, "repo")
+	require.NoError(t, os.MkdirAll(dst, 0o755))
+	err := Sync(filepath.Join(root, "missing"), dst)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "run `npub build` first")
 }

--- a/internal/deploy/deploy_test.go
+++ b/internal/deploy/deploy_test.go
@@ -28,13 +28,15 @@ func TestRepoSlug(t *testing.T) {
 	}
 }
 
-func TestCacheLayout(t *testing.T) {
-	build, err := BuildDir("https://github.com/user/site.git")
+func TestDefaultCacheDir(t *testing.T) {
+	dir, err := DefaultCacheDir("https://github.com/user/site.git")
 	require.NoError(t, err)
-	gitDir, err := GitDir("https://github.com/user/site.git")
-	require.NoError(t, err)
-	assert.Equal(t, filepath.Dir(build), filepath.Dir(gitDir), "build and git share a parent")
-	assert.Equal(t, "build", filepath.Base(build))
-	assert.Equal(t, "git", filepath.Base(gitDir))
-	assert.Equal(t, "site", filepath.Base(filepath.Dir(build)))
+	assert.Equal(t, "site", filepath.Base(dir))
+	assert.Equal(t, "npub", filepath.Base(filepath.Dir(dir)))
+}
+
+func TestBuildAndGitDir(t *testing.T) {
+	cache := "/tmp/whatever"
+	assert.Equal(t, "/tmp/whatever/build", BuildDir(cache))
+	assert.Equal(t, "/tmp/whatever/git", GitDir(cache))
 }

--- a/internal/deploy/deploy_test.go
+++ b/internal/deploy/deploy_test.go
@@ -1,6 +1,7 @@
 package deploy
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -39,4 +40,48 @@ func TestBuildAndGitDir(t *testing.T) {
 	cache := "/tmp/whatever"
 	assert.Equal(t, "/tmp/whatever/build", BuildDir(cache))
 	assert.Equal(t, "/tmp/whatever/git", GitDir(cache))
+}
+
+func TestPrepareRefusesEmptyBuildDir(t *testing.T) {
+	root := t.TempDir()
+	buildDir := filepath.Join(root, "build")
+	gitDir := filepath.Join(root, "git")
+	require.NoError(t, os.MkdirAll(buildDir, 0o755))
+
+	err := Prepare("https://example.com/repo.git", gitDir, buildDir, Options{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is empty")
+	assert.Contains(t, err.Error(), "npub build")
+
+	// gitDir was never touched: no destructive clone happened against
+	// repoURL because we bailed before touching the network.
+	_, statErr := os.Stat(gitDir)
+	assert.True(t, os.IsNotExist(statErr), "gitDir should not have been created")
+}
+
+func TestPrepareRefusesMissingBuildDir(t *testing.T) {
+	root := t.TempDir()
+	err := Prepare("https://example.com/repo.git",
+		filepath.Join(root, "git"),
+		filepath.Join(root, "missing"),
+		Options{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not exist")
+	assert.Contains(t, err.Error(), "npub build")
+}
+
+func TestPrepareTreatsDotfilesAsNonContent(t *testing.T) {
+	// A dir holding only dotfiles (e.g. a .DS_Store the user accidentally
+	// dropped) is still considered empty for deploy purposes.
+	root := t.TempDir()
+	buildDir := filepath.Join(root, "build")
+	require.NoError(t, os.MkdirAll(buildDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(buildDir, ".DS_Store"), []byte("x"), 0o644))
+
+	err := Prepare("https://example.com/repo.git",
+		filepath.Join(root, "git"),
+		buildDir,
+		Options{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is empty")
 }

--- a/internal/deploy/deploy_test.go
+++ b/internal/deploy/deploy_test.go
@@ -1,0 +1,27 @@
+package deploy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRepoSlug(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"https with .git", "https://github.com/user/repo.git", "repo"},
+		{"https without .git", "https://github.com/user/repo", "repo"},
+		{"ssh with .git", "git@github.com:user/repo.git", "repo"},
+		{"trailing slash", "https://github.com/user/repo/", "repo"},
+		{"only basename", "repo.git", "repo"},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, RepoSlug(tt.in))
+		})
+	}
+}

--- a/npub.yml.sample
+++ b/npub.yml.sample
@@ -32,6 +32,6 @@
 
 # Git repository that hosts the published site. When set, `npub build`
 # writes the site to ~/.cache/npub/<repo>/build (offline) and `npub deploy`
-# clones the remote into ~/.cache/npub/<repo>/repo, mirrors build/ into it,
-# commits, and pushes.
+# bare-clones the remote into ~/.cache/npub/<repo>/git and commits the
+# build directory's contents directly via git's --git-dir + --work-tree.
 # deploy_repo: ""

--- a/npub.yml.sample
+++ b/npub.yml.sample
@@ -8,9 +8,6 @@
 # Directory for cached image assets. Defaults to <notes_path>/images.
 # assets_path: ""
 
-# Directory where the generated site is written.
-# build_path: "./dist"
-
 # Directory with static files copied to the build output root.
 # Defaults to <notes_path>/static.
 # static_path: ""
@@ -33,7 +30,8 @@
 # Optional short paragraph shown above the posts list on the index page.
 # intro: ""
 
-# Git repository that hosts the published site. Required for `npub deploy`.
-# The deploy command clones into ~/.cache/npub/<repo>, builds the site there,
+# Git repository that hosts the published site. When set, `npub build`
+# writes the site to ~/.cache/npub/<repo>/build (offline) and `npub deploy`
+# clones the remote into ~/.cache/npub/<repo>/repo, mirrors build/ into it,
 # commits, and pushes.
 # deploy_repo: ""

--- a/npub.yml.sample
+++ b/npub.yml.sample
@@ -32,3 +32,8 @@
 
 # Optional short paragraph shown above the posts list on the index page.
 # intro: ""
+
+# Git repository that hosts the published site. Required for `npub deploy`.
+# The deploy command clones into ~/.cache/npub/<repo>, builds the site there,
+# commits, and pushes.
+# deploy_repo: ""

--- a/npub.yml.sample
+++ b/npub.yml.sample
@@ -31,7 +31,12 @@
 # intro: ""
 
 # Git repository that hosts the published site. When set, `npub build`
-# writes the site to ~/.cache/npub/<repo>/build (offline) and `npub deploy`
-# bare-clones the remote into ~/.cache/npub/<repo>/git and commits the
-# build directory's contents directly via git's --git-dir + --work-tree.
+# writes the site to <cache_path>/build (offline) and `npub deploy`
+# bare-clones the remote into <cache_path>/git and commits the build
+# directory's contents directly via git's --git-dir + --work-tree.
 # deploy_repo: ""
+
+# Per-site cache directory that holds build/ and git/. Defaults to
+# ~/.cache/npub/<repo>. Override to keep cache state on a different volume
+# or to give multiple npub.yml configs distinct cache locations.
+# cache_path: ""


### PR DESCRIPTION
## Summary

Adds a new `deploy` command that builds the site directly into a local working copy of a git repository and pushes the result. This enables automated site deployment workflows.

The implementation includes:

- New `internal/deploy` package that manages a local git working copy:
  - `Prepare()` clones the deploy repository on first use, then fetches and hard-resets to the remote default branch on subsequent runs
  - `Commit()` stages changes and creates a commit with a timestamp message
  - `Push()` pushes the current branch to its upstream
  - Helper functions for deriving cache directories and repository slugs from URLs
  - Support for detecting the remote's default branch (main/master/etc.)

- New `deploy` CLI command that:
  - Validates the `deploy_repo` configuration is set
  - Prepares the working copy in `~/.cache/npub/<repo>`
  - Builds the site directly into the working copy
  - Commits changes with a timestamp
  - Optionally pushes with `--dry-run` flag to skip the push step

- Configuration updates:
  - Added `deploy_repo` field to config struct
  - Updated sample config and README with documentation

## References

- Adds unit tests for `RepoSlug()` function covering various URL formats (https, ssh, with/without .git suffix)
- Closes #77
