### PR TITLE
Switch notes import path from notesctl to notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.15]
+
+### Changed
+
+- Re-point the `notes` library dependency from `github.com/dreikanter/notesctl` to `github.com/dreikanter/notes` to follow the upstream rename. No behavior change ([#81]).
+
+[#81]: https://github.com/dreikanter/npub/pull/81
+
 ## [0.2.14] - 2026-05-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ npub deploy
 
 ## Notes format
 
-Notes are Markdown files managed by [notesctl](https://github.com/dreikanter/notesctl). A note becomes part of the published site when its frontmatter includes `public: true`.
+Notes are Markdown files managed by [notes](https://github.com/dreikanter/notes). A note becomes part of the published site when its frontmatter includes `public: true`.
 
 ## Versioning
 

--- a/cmd/npub/main.go
+++ b/cmd/npub/main.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dreikanter/notesctl/note"
+	"github.com/dreikanter/notes/note"
 	"github.com/dreikanter/npub"
 	"github.com/dreikanter/npub/internal/build"
 	"github.com/dreikanter/npub/internal/config"

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,9 @@ go 1.25.9
 
 require (
 	github.com/alecthomas/chroma/v2 v2.23.1
-	github.com/dreikanter/notesctl v0.3.26
+	github.com/dreikanter/notes v0.3.30-0.20260502093346-79c50e4c31e1
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
 	github.com/yuin/goldmark v1.8.2
 	github.com/yuin/goldmark-highlighting/v2 v2.0.0-20230729083705-37449abec8cc
@@ -18,7 +19,6 @@ require (
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/dlclark/regexp2 v1.4.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55k
 github.com/dlclark/regexp2 v1.7.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dlclark/regexp2 v1.12.0 h1:0j4c5qQmnC6XOWNjP3PIXURXN2gWx76rd3KvgdPkCz8=
 github.com/dlclark/regexp2 v1.12.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/dreikanter/notesctl v0.3.26 h1:caFobS7sO310iDurRUw8wy2hvR5jiSWFZKkt0mTqm+E=
-github.com/dreikanter/notesctl v0.3.26/go.mod h1:IWa7NgGlbmEL9TXAYo8OG6o34PF24HZbS/hVJzOZwc8=
+github.com/dreikanter/notes v0.3.30-0.20260502093346-79c50e4c31e1 h1:XaDHo6WjcQxaUctYLVxgJXpFyDeuOuFEgO7GH6uIEDQ=
+github.com/dreikanter/notes v0.3.30-0.20260502093346-79c50e4c31e1/go.mod h1:FzuOTsqeA9XIShsPyNFxUOcchyjcLccjWw9QhDKW4no=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -17,7 +17,7 @@ import (
 
 	texttemplate "text/template"
 
-	"github.com/dreikanter/notesctl/note"
+	"github.com/dreikanter/notes/note"
 	"github.com/dreikanter/npub/internal/config"
 	"github.com/dreikanter/npub/internal/images"
 	"github.com/dreikanter/npub/internal/page"

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dreikanter/notesctl/note"
+	"github.com/dreikanter/notes/note"
 	"github.com/dreikanter/npub/internal/config"
 	"github.com/dreikanter/npub/internal/page"
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
## Summary

- Re-point the `notes` library dependency from `github.com/dreikanter/notesctl` to `github.com/dreikanter/notes` to follow the upstream rename
- Pinned to a pseudo-version of the rename branch ([dreikanter/notes#270](https://github.com/dreikanter/notes/pull/270)); will be retagged once that PR is merged and a new release is cut