### PR TITLE
Pin notes dependency to v0.3.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.16]
+
+### Changed
+
+- Pin `github.com/dreikanter/notes` to the released `v0.3.30` tag, replacing the pseudo-version introduced in #81 ([#82]).
+
+[#82]: https://github.com/dreikanter/npub/pull/82
+
 ## [0.2.15]
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.9
 
 require (
 	github.com/alecthomas/chroma/v2 v2.23.1
-	github.com/dreikanter/notes v0.3.30-0.20260502093346-79c50e4c31e1
+	github.com/dreikanter/notes v0.3.30
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -14,8 +14,8 @@ github.com/dlclark/regexp2 v1.4.0/go.mod h1:2pZnwuY/m+8K6iRw6wQdMtk+rH5tNGR1i55k
 github.com/dlclark/regexp2 v1.7.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dlclark/regexp2 v1.12.0 h1:0j4c5qQmnC6XOWNjP3PIXURXN2gWx76rd3KvgdPkCz8=
 github.com/dlclark/regexp2 v1.12.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/dreikanter/notes v0.3.30-0.20260502093346-79c50e4c31e1 h1:XaDHo6WjcQxaUctYLVxgJXpFyDeuOuFEgO7GH6uIEDQ=
-github.com/dreikanter/notes v0.3.30-0.20260502093346-79c50e4c31e1/go.mod h1:FzuOTsqeA9XIShsPyNFxUOcchyjcLccjWw9QhDKW4no=
+github.com/dreikanter/notes v0.3.30 h1:RWJc78murQMbWf8sc3bqXQB+NHLe7+3n5cs0/XCOZRU=
+github.com/dreikanter/notes v0.3.30/go.mod h1:FzuOTsqeA9XIShsPyNFxUOcchyjcLccjWw9QhDKW4no=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=


### PR DESCRIPTION
## Summary

- Replace the pseudo-version pin from #81 with the released `github.com/dreikanter/notes` v0.3.30 tag

## References

- Relates to #81