### PR TITLE
Adopt Unreleased-first release workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,10 @@
 
 -
 
+## Checklist
+
+- [ ] Updated `CHANGELOG.md` under `Unreleased`, or change is internal-only
+
 ## References
 
 - Closes #

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -14,19 +14,42 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: main
           fetch-depth: 0
-      - name: Tag from CHANGELOG
+      - name: Tag from CHANGELOG when version changed
         run: |
-          VERSION=$(grep -m1 -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | tr -d '[]' | awk '{print $2}')
+          set -euo pipefail
+
+          version_from_ref() {
+            git show "$1:CHANGELOG.md" |
+              grep -m1 -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' |
+              tr -d '[]' |
+              awk '{print $2}'
+          }
+
+          VERSION=$(version_from_ref HEAD || true)
+          PREV_REF="${{ github.event.pull_request.base.sha }}"
+          if ! git rev-parse -q --verify "$PREV_REF^{commit}" >/dev/null; then
+            PREV_REF="HEAD^1"
+          fi
+          PREV_VERSION=$(version_from_ref "$PREV_REF" || true)
+
           if [ -z "$VERSION" ]; then
             echo "No version heading found in CHANGELOG.md" >&2
             exit 1
           fi
+
+          if [ "$VERSION" = "$PREV_VERSION" ]; then
+            echo "Topmost CHANGELOG version unchanged ($VERSION); skipping"
+            exit 0
+          fi
+
           NEXT="v$VERSION"
           if git rev-parse -q --verify "refs/tags/$NEXT" >/dev/null; then
             echo "Tag $NEXT already exists; skipping"
             exit 0
           fi
+
           git tag "$NEXT"
           git push origin "$NEXT"
           echo "Tagged $NEXT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Changed
 
-- Adopt an Unreleased-first changelog and release-PR versioning workflow so multiple PRs can be bundled into one release.
+- Adopt an Unreleased-first changelog and release-PR versioning workflow so multiple PRs can be bundled into one release ([#83]).
+
+[#83]: https://github.com/dreikanter/npub/pull/83
 
 ## [0.2.16]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Adopt an Unreleased-first changelog and release-PR versioning workflow so multiple PRs can be bundled into one release.
+
 ## [0.2.16]
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,10 +17,10 @@ Version is set at build time via git tags and `-ldflags`. The `Version` var in
 `cmd/npub/main.go` defaults to `"dev"` and is overridden by `make install` /
 `make build` using `git describe --tags`.
 
-On PR merge, GitHub Actions (`.github/workflows/tag.yml`) reads the topmost
-`## [X.Y.Z]` heading from `CHANGELOG.md` and pushes `vX.Y.Z` as a git tag. The
-CHANGELOG is the source of truth for the version — bump major/minor/patch by
-writing the desired heading in the PR.
+Releases are created by dedicated release PRs. Regular PRs do not bump the
+version number. On release PR merge, GitHub Actions (`.github/workflows/tag.yml`)
+reads the topmost numeric `## [X.Y.Z]` heading from `CHANGELOG.md` and pushes
+`vX.Y.Z` as a git tag when that heading changed.
 
 After merging a PR, reinstall locally:
 
@@ -45,25 +45,27 @@ messages, code comments, issue comments, or anywhere else in the repository.
 
 ## Changelog
 
-Update `CHANGELOG.md` in every PR with an entry for the version that PR will
-create. The topmost `## [X.Y.Z]` heading determines the git tag pushed on
-merge.
-
-To find the next version, check the top of `CHANGELOG.md` and bump the patch
-number (or bump major/minor deliberately). Example: if the top entry is
-`## [0.2.5]`, the next PR's heading is `## [0.2.6]`.
+Use `CHANGELOG.md` as the source of truth for release notes.
 
 Rules:
-- One entry per PR — do not bundle multiple PRs into one entry
-- Use a version higher than the current top entry; any untagged version works
-- Reference the PR number (`[#N]`) in the entry and add its link at the bottom
+- Keep an `## [Unreleased]` section at the top.
+- PRs with user-visible changes should add an entry under `Unreleased`.
+- Internal-only PRs may skip the changelog.
+- Do not create a new version heading in regular PRs.
+- A release PR converts `Unreleased` into `## [X.Y.Z] - YYYY-MM-DD` and adds a
+  fresh empty `## [Unreleased]` section above it.
+- One release may include multiple PRs.
+- Reference PR numbers (`[#N]`) in changelog bullets when known and add links at
+  the bottom.
+- It is acceptable to open a PR with an `Unreleased` entry that does not yet
+  include its PR number; add the PR reference in a follow-up commit after GitHub
+  assigns the number when the entry should reference the PR.
 
-Workflow: the PR number is assigned on creation, so add the CHANGELOG entry as
-a follow-up commit on the same branch:
-1. Open the PR without the CHANGELOG entry.
-2. Note the assigned PR number.
-3. Add the CHANGELOG entry referencing that number in its own atomic commit.
-4. Push; the PR updates in place.
+Version bump guidance:
+- Patch: fixes, docs, small behavior improvements, and internal changes worth
+  releasing.
+- Minor: new commands, flags, public APIs, or meaningful new behavior.
+- Major: breaking CLI, config, schema, or Go API changes.
 
 ## Pull Requests
 


### PR DESCRIPTION
## Summary

- Add an `Unreleased` changelog section for regular PR entries
- Document the release-PR versioning workflow in `CLAUDE.md`
- Update auto-tagging to tag only when the topmost numeric changelog version changes
- Add a changelog checklist item to the PR template

## Checklist

- [x] Updated `CHANGELOG.md` under `Unreleased`, or change is internal-only
