### PR TITLE
Lock deploy cache during deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Adopt an Unreleased-first changelog and release-PR versioning workflow so multiple PRs can be bundled into one release ([#83]).
 
+### Fixed
+
+- Fail fast when another `npub deploy` is already using the same cache directory, avoiding concurrent git index mutations.
+
 [#83]: https://github.com/dreikanter/npub/pull/83
 
 ## [0.2.16]

--- a/cmd/npub/main.go
+++ b/cmd/npub/main.go
@@ -121,6 +121,12 @@ With --dry-run, deploy commits locally but skips the push.`,
 		if err != nil {
 			return err
 		}
+		lock, err := deploy.AcquireLock(cacheDir)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = lock.Release() }()
+
 		buildDir := deploy.BuildDir(cacheDir)
 		gitDir := deploy.GitDir(cacheDir)
 

--- a/internal/deploy/deploy_test.go
+++ b/internal/deploy/deploy_test.go
@@ -36,10 +36,29 @@ func TestDefaultCacheDir(t *testing.T) {
 	assert.Equal(t, "npub", filepath.Base(filepath.Dir(dir)))
 }
 
-func TestBuildAndGitDir(t *testing.T) {
+func TestBuildGitAndLockDir(t *testing.T) {
 	cache := "/tmp/whatever"
 	assert.Equal(t, "/tmp/whatever/build", BuildDir(cache))
 	assert.Equal(t, "/tmp/whatever/git", GitDir(cache))
+	assert.Equal(t, "/tmp/whatever/.deploy.lock", LockPath(cache))
+}
+
+func TestAcquireLockRejectsConcurrentDeploy(t *testing.T) {
+	cache := t.TempDir()
+
+	lock, err := AcquireLock(cache)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, lock.Release()) }()
+
+	second, err := AcquireLock(cache)
+	require.Error(t, err)
+	assert.Nil(t, second)
+	assert.Contains(t, err.Error(), "another `npub deploy` is in progress")
+	assert.Contains(t, err.Error(), LockPath(cache))
+
+	require.NoError(t, lock.Release())
+	lock, err = AcquireLock(cache)
+	require.NoError(t, err)
 }
 
 func TestPrepareRefusesEmptyBuildDir(t *testing.T) {

--- a/internal/deploy/lock.go
+++ b/internal/deploy/lock.go
@@ -1,0 +1,65 @@
+package deploy
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+const deployLockFile = ".deploy.lock"
+
+var errLockHeld = errors.New("deploy lock already held")
+
+// LockPath returns the sentinel file used to serialize npub deploy runs for a
+// cache directory.
+func LockPath(cacheDir string) string {
+	return filepath.Join(cacheDir, deployLockFile)
+}
+
+// Lock is an exclusive deploy cache lock. Call Release when the deploy run is
+// finished.
+type Lock struct {
+	path string
+	file *os.File
+}
+
+// AcquireLock takes an exclusive, non-blocking lock for cacheDir. It fails fast
+// when another npub deploy process already holds the same cache lock.
+func AcquireLock(cacheDir string) (*Lock, error) {
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		return nil, fmt.Errorf("creating cache directory %s: %w", cacheDir, err)
+	}
+
+	path := LockPath(cacheDir)
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("opening deploy lock %s: %w", path, err)
+	}
+
+	if err := lockFile(file); err != nil {
+		_ = file.Close()
+		if errors.Is(err, errLockHeld) {
+			return nil, fmt.Errorf("another `npub deploy` is in progress (lock at `%s`); rerun once it finishes", path)
+		}
+		return nil, fmt.Errorf("locking deploy cache %s: %w", path, err)
+	}
+
+	return &Lock{path: path, file: file}, nil
+}
+
+// Release unlocks and closes the lock file.
+func (l *Lock) Release() error {
+	if l == nil || l.file == nil {
+		return nil
+	}
+	if err := unlockFile(l.file); err != nil {
+		_ = l.file.Close()
+		return fmt.Errorf("unlocking deploy cache %s: %w", l.path, err)
+	}
+	if err := l.file.Close(); err != nil {
+		return fmt.Errorf("closing deploy lock %s: %w", l.path, err)
+	}
+	l.file = nil
+	return nil
+}

--- a/internal/deploy/lock_unix.go
+++ b/internal/deploy/lock_unix.go
@@ -1,0 +1,25 @@
+//go:build !windows
+
+package deploy
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func lockFile(file *os.File) error {
+	err := unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, unix.EWOULDBLOCK) || errors.Is(err, unix.EAGAIN) {
+		return errLockHeld
+	}
+	return err
+}
+
+func unlockFile(file *os.File) error {
+	return unix.Flock(int(file.Fd()), unix.LOCK_UN)
+}

--- a/internal/deploy/lock_windows.go
+++ b/internal/deploy/lock_windows.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+package deploy
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockFile(file *os.File) error {
+	overlapped := &windows.Overlapped{}
+	err := windows.LockFileEx(
+		windows.Handle(file.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0,
+		1,
+		0,
+		overlapped,
+	)
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+		return errLockHeld
+	}
+	return err
+}
+
+func unlockFile(file *os.File) error {
+	return windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, &windows.Overlapped{})
+}


### PR DESCRIPTION
## Summary

- add a non-blocking deploy cache lock at <cache_path>/.deploy.lock
- fail fast with a clear error when another deploy holds the lock
- cover lock path and concurrent lock rejection in tests

## Checklist

- [x] Updated `CHANGELOG.md` under `Unreleased`, or change is internal-only

## References

- Closes #80