### PR TITLE
Add managed build clear command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Add `npub clear` to remove only the managed `<cache_path>/build` output directory, guarded by an npub marker file and dangerous-path checks.
+
 ### Changed
 
 - Adopt an Unreleased-first changelog and release-PR versioning workflow so multiple PRs can be bundled into one release ([#83]).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Add `npub clear` to remove only the managed `<cache_path>/build` output directory, guarded by an npub marker file and dangerous-path checks.
+- Add `npub clear` to remove only the managed `<cache_path>/build` output directory, guarded by an npub marker file and dangerous-path checks ([#86]).
 
 ### Changed
 
@@ -14,6 +14,7 @@
 
 - Fail fast when another `npub deploy` is already using the same cache directory, avoiding concurrent git index mutations.
 
+[#86]: https://github.com/dreikanter/npub/pull/86
 [#83]: https://github.com/dreikanter/npub/pull/83
 
 ## [0.2.16]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 
+- Remove the `npub build --out` override so builds always target the managed `<cache_path>/build` directory.
 - Adopt an Unreleased-first changelog and release-PR versioning workflow so multiple PRs can be bundled into one release ([#83]).
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -125,6 +125,14 @@ npub deploy
 
 `npub deploy` keeps a bare clone of `deploy_repo` at `~/.cache/npub/<repo>/git` and uses `~/.cache/npub/<repo>/build` as a temporary work-tree (via git's `--git-dir` and `--work-tree` options) when committing. There is no second copy of the site on disk: deploy fetches, points git at the build directory, and runs `add -A` + commit + push. Stale files are removed and changed files updated by the same `add -A` pass. Use `--dry-run` to commit locally without pushing.
 
+Clear the managed build output:
+
+```sh
+npub clear
+```
+
+`npub clear` removes only the managed `<cache_path>/build` directory. It does not accept arbitrary paths or `--out`. Non-empty build output must contain npub's `.npub-build` marker, which `npub build` writes as a deletion guardrail.
+
 ## Notes format
 
 Notes are Markdown files managed by [notes](https://github.com/dreikanter/notes). A note becomes part of the published site when its frontmatter includes `public: true`.

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ All values can be overridden with CLI flags:
 
 The build output directory is not a config option. `npub build` writes to
 `<cache_path>/build` (where `cache_path` defaults to `~/.cache/npub/<repo>`).
-Pass `--out <dir>` to override. Either `deploy_repo` or `--out` must be set;
-there is no implicit `./dist`. `build` never talks to the deploy_repo
-remote — all git operations happen in `deploy`.
+Either `deploy_repo` or `cache_path` must be set; there is no implicit `./dist`.
+`build` never talks to the deploy_repo remote — all git operations happen in
+`deploy`.
 
 Priority: CLI flags > YAML config.
 
@@ -131,7 +131,7 @@ Clear the managed build output:
 npub clear
 ```
 
-`npub clear` removes only the managed `<cache_path>/build` directory. It does not accept arbitrary paths or `--out`. Non-empty build output must contain npub's `.npub-build` marker, which `npub build` writes as a deletion guardrail.
+`npub clear` removes only the managed `<cache_path>/build` directory. It does not accept arbitrary paths. Non-empty build output must contain npub's `.npub-build` marker, which `npub build` writes as a deletion guardrail.
 
 ## Notes format
 

--- a/cmd/npub/main.go
+++ b/cmd/npub/main.go
@@ -83,6 +83,17 @@ operations happen in deploy.`,
 		if err != nil {
 			return err
 		}
+		if f := cmd.Flags().Lookup("out"); f == nil || !f.Changed {
+			cacheDir, err := resolveCacheDir(cfg)
+			if err != nil {
+				return err
+			}
+			lock, err := deploy.AcquireLock(cacheDir)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = lock.Release() }()
+		}
 
 		log.Printf("building site from %s to %s", cfg.NotesPath, buildPath)
 		store := note.NewOSStore(cfg.NotesPath)
@@ -154,6 +165,54 @@ With --dry-run, deploy commits locally but skips the push.`,
 		}
 		log.Println("deploy complete")
 		return nil
+	},
+}
+
+var clearCmd = &cobra.Command{
+	Use:   "clear",
+	Short: "Clear the managed build output directory",
+	Long: `Clear the managed build output directory at <cache_path>/build.
+
+clear only operates on npub's managed cache layout. It does not accept an
+arbitrary path or --out override. The build directory must either be empty or
+contain npub's ownership marker.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfgPath, _ := cmd.Flags().GetString("config")
+		cfg, err := loadConfigForClear(cmd, cfgPath)
+		if err != nil {
+			return err
+		}
+		cacheDir, err := resolveCacheDir(cfg)
+		if err != nil {
+			return err
+		}
+		buildDir := deploy.BuildDir(cacheDir)
+
+		lock, err := deploy.AcquireLock(cacheDir)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = lock.Release() }()
+
+		if err := validateClearTarget(buildDir, cacheDir, cfg); err != nil {
+			return err
+		}
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+		if dryRun {
+			_, err := fmt.Fprintf(cmd.OutOrStdout(), "would clear %s\n", buildDir)
+			return err
+		}
+		cleared, err := clearBuildDir(buildDir)
+		if err != nil {
+			return err
+		}
+		if !cleared {
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "%s does not exist\n", buildDir)
+			return err
+		}
+		_, err = fmt.Fprintf(cmd.OutOrStdout(), "cleared %s\n", buildDir)
+		return err
 	},
 }
 
@@ -384,6 +443,120 @@ func loadConfigOpt(cmd *cobra.Command, cfgPath string) (config.Config, error) {
 	return cfg, err
 }
 
+func loadConfigForClear(cmd *cobra.Command, cfgPath string) (config.Config, error) {
+	cfg, _, err := loadConfig(cmd, cfgPath)
+	if err != nil && !strings.HasPrefix(err.Error(), "missing required fields:") {
+		return cfg, err
+	}
+	return cfg, nil
+}
+
+func clearBuildDir(buildDir string) (bool, error) {
+	info, err := os.Stat(buildDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("checking build directory %s: %w", buildDir, err)
+	}
+	if !info.IsDir() {
+		return false, fmt.Errorf("build path %s is not a directory", buildDir)
+	}
+	entries, err := os.ReadDir(buildDir)
+	if err != nil {
+		return false, fmt.Errorf("reading build directory %s: %w", buildDir, err)
+	}
+	if len(entries) > 0 {
+		if _, err := os.Stat(filepath.Join(buildDir, build.BuildMarkerName)); err != nil {
+			if os.IsNotExist(err) {
+				return false, fmt.Errorf("refusing to clear %s: directory is not marked as an npub build directory", buildDir)
+			}
+			return false, fmt.Errorf("checking build marker: %w", err)
+		}
+	}
+	if err := os.RemoveAll(buildDir); err != nil {
+		return false, fmt.Errorf("clearing %s: %w", buildDir, err)
+	}
+	return true, nil
+}
+
+func validateClearTarget(buildDir, cacheDir string, cfg config.Config) error {
+	if !samePath(buildDir, deploy.BuildDir(cacheDir)) {
+		return fmt.Errorf("refusing to clear %s: target must be exactly %s", buildDir, deploy.BuildDir(cacheDir))
+	}
+	if buildDir == "" {
+		return fmt.Errorf("refusing to clear empty build path")
+	}
+	absBuild, err := filepath.Abs(buildDir)
+	if err != nil {
+		return fmt.Errorf("resolving build path: %w", err)
+	}
+	if absBuild == string(filepath.Separator) {
+		return fmt.Errorf("refusing to clear dangerous build path: %s", absBuild)
+	}
+	if info, err := os.Lstat(absBuild); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to clear symlinked build directory: %s", absBuild)
+	} else if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("checking build path %s: %w", absBuild, err)
+	}
+
+	important := map[string]string{
+		"cache_path":  cacheDir,
+		"git dir":     deploy.GitDir(cacheDir),
+		"notes_path":  cfg.NotesPath,
+		"assets_path": cfg.AssetsPath,
+		"static_path": cfg.StaticPath,
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		important["home directory"] = home
+	}
+	if cwd, err := os.Getwd(); err == nil {
+		important["current working directory"] = cwd
+	}
+	for name, path := range important {
+		if path == "" {
+			continue
+		}
+		absPath, err := filepath.Abs(path)
+		if err != nil {
+			return fmt.Errorf("resolving %s: %w", name, err)
+		}
+		if sameAbsPath(absBuild, absPath) {
+			return fmt.Errorf("refusing to clear %s: it is the %s", absBuild, name)
+		}
+		if isAncestor(absBuild, absPath) {
+			return fmt.Errorf("refusing to clear %s: it contains the %s %s", absBuild, name, absPath)
+		}
+	}
+	return nil
+}
+
+func samePath(a, b string) bool {
+	absA, errA := filepath.Abs(a)
+	absB, errB := filepath.Abs(b)
+	if errA != nil || errB != nil {
+		return filepath.Clean(a) == filepath.Clean(b)
+	}
+	return sameAbsPath(absA, absB)
+}
+
+func sameAbsPath(a, b string) bool {
+	return filepath.Clean(a) == filepath.Clean(b)
+}
+
+func isAncestor(parent, child string) bool {
+	parent = filepath.Clean(parent)
+	child = filepath.Clean(child)
+	if sameAbsPath(parent, child) {
+		return false
+	}
+	rel, err := filepath.Rel(parent, child)
+	if err != nil {
+		return false
+	}
+	return rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
 func init() {
 	if Version == "dev" {
 		if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "(devel)" {
@@ -399,6 +572,7 @@ func init() {
 	buildCmd.Flags().String("out", "", "output directory (overrides the deploy_repo cache build path)")
 	configCmd.Flags().String("out", "", "preview build path override")
 	deployCmd.Flags().Bool("dry-run", false, "commit locally but skip git push")
+	clearCmd.Flags().Bool("dry-run", false, "print the managed build directory without removing it")
 
 	serveCmd.Flags().String("dir", "", "directory to serve (defaults to the deploy_repo cache build path)")
 	serveCmd.Flags().String("host", "localhost", "interface to bind")
@@ -408,6 +582,7 @@ func init() {
 	rootCmd.AddCommand(buildCmd)
 	rootCmd.AddCommand(configCmd)
 	rootCmd.AddCommand(deployCmd)
+	rootCmd.AddCommand(clearCmd)
 	rootCmd.AddCommand(serveCmd)
 }
 

--- a/cmd/npub/main.go
+++ b/cmd/npub/main.go
@@ -62,11 +62,11 @@ var buildCmd = &cobra.Command{
 	Long: `Read notes from notes_path, render to HTML, and write the site files.
 
 Output directory resolution:
-  --out <dir>              explicit override
   deploy_repo (in YAML)    <cache_path>/build (cache_path defaults to
                            ~/.cache/npub/<repo>)
+  cache_path (in YAML)     <cache_path>/build
 
-One of the two must be configured.
+One of deploy_repo or cache_path must be configured.
 
 build runs offline: it never talks to the deploy_repo remote. All git
 operations happen in deploy.`,
@@ -80,21 +80,16 @@ operations happen in deploy.`,
 			return err
 		}
 
-		buildPath, err := resolveBuildPath(cmd, cfg)
+		cacheDir, err := resolveCacheDir(cfg)
 		if err != nil {
 			return err
 		}
-		if f := cmd.Flags().Lookup("out"); f == nil || !f.Changed {
-			cacheDir, err := resolveCacheDir(cfg)
-			if err != nil {
-				return err
-			}
-			lock, err := deploy.AcquireLock(cacheDir)
-			if err != nil {
-				return err
-			}
-			defer func() { _ = lock.Release() }()
+		buildPath := deploy.BuildDir(cacheDir)
+		lock, err := deploy.AcquireLock(cacheDir)
+		if err != nil {
+			return err
 		}
+		defer func() { _ = lock.Release() }()
 
 		log.Printf("building site from %s to %s", cfg.NotesPath, buildPath)
 		store := note.NewOSStore(cfg.NotesPath)
@@ -175,8 +170,8 @@ var clearCmd = &cobra.Command{
 	Long: `Clear the managed build output directory at <cache_path>/build.
 
 clear only operates on npub's managed cache layout. It does not accept an
-arbitrary path or --out override. The build directory must either be empty or
-contain npub's ownership marker.`,
+arbitrary path override. The build directory must either be empty or contain
+npub's ownership marker.`,
 	Args: cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfgPath, _ := cmd.Flags().GetString("config")
@@ -278,11 +273,11 @@ set in the config for the implicit path to resolve.`,
 			if err != nil {
 				return err
 			}
-			resolved, rerr := resolveBuildPath(cmd, cfg)
+			cacheDir, rerr := resolveCacheDir(cfg)
 			if rerr != nil {
 				return rerr
 			}
-			dir = resolved
+			dir = deploy.BuildDir(cacheDir)
 		}
 		dir = config.ExpandPath(dir)
 		info, err := os.Stat(dir)
@@ -333,30 +328,10 @@ func resolveCacheDir(cfg config.Config) (string, error) {
 	if strings.TrimSpace(cfg.CachePath) != "" {
 		return config.ExpandPath(cfg.CachePath), nil
 	}
-	return deploy.DefaultCacheDir(cfg.DeployRepo)
-}
-
-// resolveBuildPath returns the directory the build will write to or the
-// directory serve will read from. It honors a caller-provided --out flag
-// first, then falls back to <cache_path>/build when deploy_repo is set.
-// If neither is configured, the caller gets a clear error rather than a
-// surprise relative path.
-func resolveBuildPath(cmd *cobra.Command, cfg config.Config) (string, error) {
-	if f := cmd.Flags().Lookup("out"); f != nil && f.Changed {
-		return config.ExpandPath(f.Value.String()), nil
-	}
 	if strings.TrimSpace(cfg.DeployRepo) == "" {
-		flag := "--out"
-		if cmd.Name() == "serve" {
-			flag = "--dir"
-		}
-		return "", fmt.Errorf("deploy_repo is not set; configure it in %s or pass %s", config.DefaultConfigFile, flag)
+		return "", fmt.Errorf("deploy_repo or cache_path must be set in %s", config.DefaultConfigFile)
 	}
-	cache, err := resolveCacheDir(cfg)
-	if err != nil {
-		return "", err
-	}
-	return deploy.BuildDir(cache), nil
+	return deploy.DefaultCacheDir(cfg.DeployRepo)
 }
 
 func initConfig(path string) (string, error) {
@@ -590,8 +565,6 @@ func init() {
 
 	addConfigFlags(buildCmd)
 	addConfigFlags(configCmd)
-	buildCmd.Flags().String("out", "", "output directory (overrides the deploy_repo cache build path)")
-	configCmd.Flags().String("out", "", "preview build path override")
 	deployCmd.Flags().Bool("dry-run", false, "commit locally but skip git push")
 	clearCmd.Flags().Bool("dry-run", false, "print the managed build directory without removing it")
 

--- a/cmd/npub/main.go
+++ b/cmd/npub/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -189,12 +190,6 @@ contain npub's ownership marker.`,
 		}
 		buildDir := deploy.BuildDir(cacheDir)
 
-		lock, err := deploy.AcquireLock(cacheDir)
-		if err != nil {
-			return err
-		}
-		defer func() { _ = lock.Release() }()
-
 		if err := validateClearTarget(buildDir, cacheDir, cfg); err != nil {
 			return err
 		}
@@ -203,6 +198,13 @@ contain npub's ownership marker.`,
 			_, err := fmt.Fprintf(cmd.OutOrStdout(), "would clear %s\n", buildDir)
 			return err
 		}
+
+		lock, err := deploy.AcquireLock(cacheDir)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = lock.Release() }()
+
 		cleared, err := clearBuildDir(buildDir)
 		if err != nil {
 			return err
@@ -443,9 +445,12 @@ func loadConfigOpt(cmd *cobra.Command, cfgPath string) (config.Config, error) {
 	return cfg, err
 }
 
+// loadConfigForClear treats missing site metadata as non-fatal because clear
+// only needs cache_path/deploy_repo to resolve the managed build directory.
 func loadConfigForClear(cmd *cobra.Command, cfgPath string) (config.Config, error) {
 	cfg, _, err := loadConfig(cmd, cfgPath)
-	if err != nil && !strings.HasPrefix(err.Error(), "missing required fields:") {
+	var missingRequired config.MissingRequiredError
+	if err != nil && !errors.As(err, &missingRequired) {
 		return cfg, err
 	}
 	return cfg, nil
@@ -481,11 +486,11 @@ func clearBuildDir(buildDir string) (bool, error) {
 }
 
 func validateClearTarget(buildDir, cacheDir string, cfg config.Config) error {
-	if !samePath(buildDir, deploy.BuildDir(cacheDir)) {
-		return fmt.Errorf("refusing to clear %s: target must be exactly %s", buildDir, deploy.BuildDir(cacheDir))
-	}
 	if buildDir == "" {
 		return fmt.Errorf("refusing to clear empty build path")
+	}
+	if !samePath(buildDir, deploy.BuildDir(cacheDir)) {
+		return fmt.Errorf("refusing to clear %s: target must be exactly %s", buildDir, deploy.BuildDir(cacheDir))
 	}
 	absBuild, err := filepath.Abs(buildDir)
 	if err != nil {
@@ -494,10 +499,15 @@ func validateClearTarget(buildDir, cacheDir string, cfg config.Config) error {
 	if absBuild == string(filepath.Separator) {
 		return fmt.Errorf("refusing to clear dangerous build path: %s", absBuild)
 	}
-	if info, err := os.Lstat(absBuild); err == nil && info.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("refusing to clear symlinked build directory: %s", absBuild)
-	} else if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("checking build path %s: %w", absBuild, err)
+	if err := rejectSymlinkedPath(absBuild); err != nil {
+		return err
+	}
+	absCache, err := filepath.Abs(cacheDir)
+	if err != nil {
+		return fmt.Errorf("resolving cache_path: %w", err)
+	}
+	if err := rejectSymlinkedPath(absCache); err != nil {
+		return err
 	}
 
 	important := map[string]string{
@@ -527,6 +537,17 @@ func validateClearTarget(buildDir, cacheDir string, cfg config.Config) error {
 		if isAncestor(absBuild, absPath) {
 			return fmt.Errorf("refusing to clear %s: it contains the %s %s", absBuild, name, absPath)
 		}
+	}
+	return nil
+}
+
+func rejectSymlinkedPath(path string) error {
+	info, err := os.Lstat(filepath.Clean(path))
+	if err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("refusing to clear symlinked path: %s", path)
+	}
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("checking path %s: %w", path, err)
 	}
 	return nil
 }

--- a/cmd/npub/main_test.go
+++ b/cmd/npub/main_test.go
@@ -6,7 +6,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/dreikanter/npub/internal/build"
 	"github.com/dreikanter/npub/internal/config"
+	"github.com/dreikanter/npub/internal/deploy"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
@@ -193,6 +195,92 @@ notes_path: "/tmp/notes"
 	assert.Contains(t, out, "notes_path: /tmp/notes")
 }
 
+func TestClearCommandDryRunUsesManagedBuildDir(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+	cfgPath := filepath.Join(dir, config.DefaultConfigFile)
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+notes_path: "/tmp/notes"
+site_root_url: "https://example.com"
+site_name: "Test Site"
+author_name: "Test Author"
+cache_path: "`+cacheDir+`"
+`), 0o644))
+
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{"clear", "--config", cfgPath, "--dry-run"})
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+		resetFlags(rootCmd)
+	})
+
+	require.NoError(t, rootCmd.Execute())
+	assert.Contains(t, buf.String(), "would clear "+deploy.BuildDir(cacheDir))
+	assert.NoDirExists(t, deploy.BuildDir(cacheDir))
+}
+
+func TestClearCommandRejectsPositionalPathAndHasNoOutFlag(t *testing.T) {
+	assert.Nil(t, clearCmd.Flags().Lookup("out"))
+
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{"clear", "/tmp/site"})
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+		resetFlags(rootCmd)
+	})
+
+	err := rootCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown command")
+}
+
+func TestClearBuildDirRequiresMarkerForNonEmptyDir(t *testing.T) {
+	buildDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(buildDir, "index.html"), []byte("site"), 0o644))
+
+	cleared, err := clearBuildDir(buildDir)
+	require.Error(t, err)
+	assert.False(t, cleared)
+	assert.Contains(t, err.Error(), "not marked as an npub build directory")
+	assert.FileExists(t, filepath.Join(buildDir, "index.html"))
+}
+
+func TestClearBuildDirRemovesMarkedDir(t *testing.T) {
+	buildDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(buildDir, "index.html"), []byte("site"), 0o644))
+	require.NoError(t, build.WriteBuildMarker(buildDir))
+
+	cleared, err := clearBuildDir(buildDir)
+	require.NoError(t, err)
+	assert.True(t, cleared)
+	assert.NoDirExists(t, buildDir)
+}
+
+func TestValidateClearTargetRejectsImportantPaths(t *testing.T) {
+	cacheDir := t.TempDir()
+	cfg := config.Config{NotesPath: deploy.BuildDir(cacheDir)}
+
+	err := validateClearTarget(deploy.BuildDir(cacheDir), cacheDir, cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "notes_path")
+}
+
+func TestValidateClearTargetRejectsSymlink(t *testing.T) {
+	cacheDir := t.TempDir()
+	realBuild := filepath.Join(cacheDir, "real-build")
+	require.NoError(t, os.MkdirAll(realBuild, 0o755))
+	buildDir := deploy.BuildDir(cacheDir)
+	require.NoError(t, os.Symlink(realBuild, buildDir))
+
+	err := validateClearTarget(buildDir, cacheDir, config.Config{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "symlinked")
+}
+
 func TestResolveConfigPath(t *testing.T) {
 	notesDir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(notesDir, config.DefaultConfigFile), []byte("---\n"), 0o644))
@@ -237,4 +325,3 @@ func TestResolveConfigPath(t *testing.T) {
 		})
 	}
 }
-

--- a/cmd/npub/main_test.go
+++ b/cmd/npub/main_test.go
@@ -221,8 +221,9 @@ cache_path: "`+cacheDir+`"
 	assert.NoDirExists(t, deploy.BuildDir(cacheDir))
 }
 
-func TestClearCommandRejectsPositionalPathAndHasNoOutFlag(t *testing.T) {
+func TestClearCommandRejectsPositionalPathAndBuildHasNoOutFlag(t *testing.T) {
 	assert.Nil(t, clearCmd.Flags().Lookup("out"))
+	assert.Nil(t, buildCmd.Flags().Lookup("out"))
 
 	var buf bytes.Buffer
 	rootCmd.SetOut(&buf)

--- a/cmd/npub/main_test.go
+++ b/cmd/npub/main_test.go
@@ -233,9 +233,7 @@ func TestClearCommandRejectsPositionalPathAndHasNoOutFlag(t *testing.T) {
 		resetFlags(rootCmd)
 	})
 
-	err := rootCmd.Execute()
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "unknown command")
+	require.Error(t, rootCmd.Execute())
 }
 
 func TestClearBuildDirRequiresMarkerForNonEmptyDir(t *testing.T) {
@@ -260,6 +258,23 @@ func TestClearBuildDirRemovesMarkedDir(t *testing.T) {
 	assert.NoDirExists(t, buildDir)
 }
 
+func TestClearBuildDirRemovesEmptyUnmarkedDir(t *testing.T) {
+	buildDir := t.TempDir()
+
+	cleared, err := clearBuildDir(buildDir)
+	require.NoError(t, err)
+	assert.True(t, cleared)
+	assert.NoDirExists(t, buildDir)
+}
+
+func TestClearBuildDirReturnsFalseForMissingDir(t *testing.T) {
+	buildDir := filepath.Join(t.TempDir(), "missing")
+
+	cleared, err := clearBuildDir(buildDir)
+	require.NoError(t, err)
+	assert.False(t, cleared)
+}
+
 func TestValidateClearTargetRejectsImportantPaths(t *testing.T) {
 	cacheDir := t.TempDir()
 	cfg := config.Config{NotesPath: deploy.BuildDir(cacheDir)}
@@ -277,6 +292,18 @@ func TestValidateClearTargetRejectsSymlink(t *testing.T) {
 	require.NoError(t, os.Symlink(realBuild, buildDir))
 
 	err := validateClearTarget(buildDir, cacheDir, config.Config{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "symlinked")
+}
+
+func TestValidateClearTargetRejectsSymlinkedCachePath(t *testing.T) {
+	root := t.TempDir()
+	realCache := filepath.Join(root, "real-cache")
+	require.NoError(t, os.MkdirAll(realCache, 0o755))
+	cacheDir := filepath.Join(root, "cache-link")
+	require.NoError(t, os.Symlink(realCache, cacheDir))
+
+	err := validateClearTarget(deploy.BuildDir(cacheDir), cacheDir, config.Config{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "symlinked")
 }

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -100,6 +100,23 @@ type feedNoteData struct {
 	Body  string
 }
 
+// BuildMarkerName is the marker file npub writes into managed build output.
+const BuildMarkerName = ".npub-build"
+
+const buildMarkerText = "This directory is managed by npub and may be cleared by `npub clear`.\n" +
+	"This file is a safety guardrail to help prevent accidental deletion of unrelated directories.\n"
+
+// WriteBuildMarker writes the npub ownership marker into buildPath.
+func WriteBuildMarker(buildPath string) error {
+	if err := os.MkdirAll(buildPath, 0o755); err != nil {
+		return fmt.Errorf("creating build dir: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(buildPath, BuildMarkerName), []byte(buildMarkerText), 0o644); err != nil {
+		return fmt.Errorf("writing build marker: %w", err)
+	}
+	return nil
+}
+
 // cleanBuildDir removes all non-dotfile entries from the build directory,
 // preserving dotfiles and dotdirs (e.g. .git, .nojekyll).
 func cleanBuildDir(buildPath string) error {
@@ -377,7 +394,7 @@ func Build(store note.Store, cfg config.Config, buildPath string, assets Assets)
 		return fmt.Errorf("writing feed: %w", err)
 	}
 
-	return nil
+	return WriteBuildMarker(buildPath)
 }
 
 // buildNotePages converts note.Entry values into page.NotePage models and

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -200,8 +200,11 @@ type Assets struct {
 // the directory the rendered files are written to; cfg supplies everything
 // else (notes location, site metadata, etc).
 func Build(store note.Store, cfg config.Config, buildPath string, assets Assets) error {
-	// 0. Clean build directory.
+	// 0. Clean build directory and mark it as npub-managed before rendering.
 	if err := cleanBuildDir(buildPath); err != nil {
+		return err
+	}
+	if err := WriteBuildMarker(buildPath); err != nil {
 		return err
 	}
 
@@ -394,7 +397,7 @@ func Build(store note.Store, cfg config.Config, buildPath string, assets Assets)
 		return fmt.Errorf("writing feed: %w", err)
 	}
 
-	return WriteBuildMarker(buildPath)
+	return nil
 }
 
 // buildNotePages converts note.Entry values into page.NotePage models and

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -39,6 +39,17 @@ func TestCleanBuildDirNonExistent(t *testing.T) {
 	assert.NoError(t, cleanBuildDir("/tmp/npub-does-not-exist-"+t.Name()))
 }
 
+func TestWriteBuildMarker(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, WriteBuildMarker(dir))
+
+	data, err := os.ReadFile(filepath.Join(dir, BuildMarkerName))
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "managed by npub")
+	assert.Contains(t, string(data), "npub clear")
+}
+
 func TestCleanBuildDirRejectsRoot(t *testing.T) {
 	require.Error(t, cleanBuildDir("/"))
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,15 @@ import (
 // DefaultConfigFile is the conventional config file name.
 const DefaultConfigFile = "npub.yml"
 
+// MissingRequiredError reports required config fields that were not set.
+type MissingRequiredError struct {
+	Fields []string
+}
+
+func (e MissingRequiredError) Error() string {
+	return "missing required fields: " + strings.Join(e.Fields, ", ")
+}
+
 // Config holds all configuration for a npub build.
 type Config struct {
 	NotesPath   string `yaml:"notes_path"`
@@ -133,7 +142,7 @@ func Load(yamlPath string, flagOverrides map[string]string) (Config, error) {
 		missing = append(missing, "author_name")
 	}
 	if len(missing) > 0 {
-		return cfg, fmt.Errorf("missing required fields: %s", strings.Join(missing, ", "))
+		return cfg, MissingRequiredError{Fields: missing}
 	}
 
 	return cfg, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -58,6 +59,9 @@ notes_path: "/tmp/notes"
 
 	_, err := Load(yamlPath, nil)
 	require.Error(t, err)
+	var missing MissingRequiredError
+	require.True(t, errors.As(err, &missing))
+	assert.ElementsMatch(t, []string{"site_root_url", "site_name", "author_name"}, missing.Fields)
 }
 
 func TestAssetsPathDefaultsToNotesImages(t *testing.T) {

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -69,6 +69,8 @@ func RepoSlug(repoURL string) string {
 	return s
 }
 
+const buildMarkerName = ".npub-build"
+
 // Options controls Prepare, Commit, and Push.
 type Options struct {
 	Stdout io.Writer
@@ -150,6 +152,10 @@ func Prepare(repoURL, gitDir, buildDir string, opt Options) error {
 		}
 	}
 
+	if err := ensureGitExclude(gitDir, buildMarkerName); err != nil {
+		return err
+	}
+
 	if err := runGit(stdout, stderr, "", "--git-dir="+gitDir, "fetch", "--prune", "origin"); err != nil {
 		return fmt.Errorf("fetching %s: %w", repoURL, err)
 	}
@@ -164,6 +170,36 @@ func Prepare(repoURL, gitDir, buildDir string, opt Options) error {
 	if err := runGit(stdout, stderr, "", "--git-dir="+gitDir, "--work-tree="+buildDir,
 		"reset", "--mixed", "origin/"+branch); err != nil {
 		return fmt.Errorf("resetting to origin/%s: %w", branch, err)
+	}
+	return nil
+}
+
+func ensureGitExclude(gitDir, pattern string) error {
+	excludePath := filepath.Join(gitDir, "info", "exclude")
+	if err := os.MkdirAll(filepath.Dir(excludePath), 0o755); err != nil {
+		return fmt.Errorf("creating git exclude directory %s: %w", filepath.Dir(excludePath), err)
+	}
+	data, err := os.ReadFile(excludePath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("reading git exclude %s: %w", excludePath, err)
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) == pattern {
+			return nil
+		}
+	}
+	file, err := os.OpenFile(excludePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("opening git exclude %s: %w", excludePath, err)
+	}
+	defer func() { _ = file.Close() }()
+	if len(data) > 0 && !bytes.HasSuffix(data, []byte("\n")) {
+		if _, err := file.WriteString("\n"); err != nil {
+			return fmt.Errorf("writing git exclude %s: %w", excludePath, err)
+		}
+	}
+	if _, err := fmt.Fprintf(file, "%s\n", pattern); err != nil {
+		return fmt.Errorf("writing git exclude %s: %w", excludePath, err)
 	}
 	return nil
 }

--- a/internal/deploy/deploy_test.go
+++ b/internal/deploy/deploy_test.go
@@ -43,7 +43,7 @@ func TestBuildGitAndLockDir(t *testing.T) {
 	assert.Equal(t, "/tmp/whatever/.deploy.lock", LockPath(cache))
 }
 
-func TestAcquireLockRejectsConcurrentDeploy(t *testing.T) {
+func TestAcquireLockRejectsConcurrentUse(t *testing.T) {
 	cache := t.TempDir()
 
 	lock, err := AcquireLock(cache)
@@ -53,7 +53,7 @@ func TestAcquireLockRejectsConcurrentDeploy(t *testing.T) {
 	second, err := AcquireLock(cache)
 	require.Error(t, err)
 	assert.Nil(t, second)
-	assert.Contains(t, err.Error(), "another `npub deploy` is in progress")
+	assert.Contains(t, err.Error(), "another `npub` command is using this cache")
 	assert.Contains(t, err.Error(), LockPath(cache))
 
 	require.NoError(t, lock.Release())

--- a/internal/deploy/deploy_test.go
+++ b/internal/deploy/deploy_test.go
@@ -61,6 +61,17 @@ func TestAcquireLockRejectsConcurrentUse(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestEnsureGitExcludeAddsPatternOnce(t *testing.T) {
+	gitDir := t.TempDir()
+
+	require.NoError(t, ensureGitExclude(gitDir, buildMarkerName))
+	require.NoError(t, ensureGitExclude(gitDir, buildMarkerName))
+
+	data, err := os.ReadFile(filepath.Join(gitDir, "info", "exclude"))
+	require.NoError(t, err)
+	assert.Equal(t, ".npub-build\n", string(data))
+}
+
 func TestPrepareRefusesEmptyBuildDir(t *testing.T) {
 	root := t.TempDir()
 	buildDir := filepath.Join(root, "build")

--- a/internal/deploy/lock.go
+++ b/internal/deploy/lock.go
@@ -40,7 +40,7 @@ func AcquireLock(cacheDir string) (*Lock, error) {
 	if err := lockFile(file); err != nil {
 		_ = file.Close()
 		if errors.Is(err, errLockHeld) {
-			return nil, fmt.Errorf("another `npub deploy` is in progress (lock at `%s`); rerun once it finishes", path)
+			return nil, fmt.Errorf("another `npub` command is using this cache (lock at `%s`); rerun once it finishes", path)
 		}
 		return nil, fmt.Errorf("locking deploy cache %s: %w", path, err)
 	}

--- a/internal/deploy/lock.go
+++ b/internal/deploy/lock.go
@@ -7,25 +7,25 @@ import (
 	"path/filepath"
 )
 
-const deployLockFile = ".deploy.lock"
+const cacheLockFile = ".deploy.lock"
 
-var errLockHeld = errors.New("deploy lock already held")
+var errLockHeld = errors.New("cache lock already held")
 
-// LockPath returns the sentinel file used to serialize npub deploy runs for a
-// cache directory.
+// LockPath returns the sentinel file used to serialize cache-mutating npub
+// commands for a cache directory.
 func LockPath(cacheDir string) string {
-	return filepath.Join(cacheDir, deployLockFile)
+	return filepath.Join(cacheDir, cacheLockFile)
 }
 
-// Lock is an exclusive deploy cache lock. Call Release when the deploy run is
-// finished.
+// Lock is an exclusive npub cache lock. Call Release when the cache operation
+// is finished.
 type Lock struct {
 	path string
 	file *os.File
 }
 
 // AcquireLock takes an exclusive, non-blocking lock for cacheDir. It fails fast
-// when another npub deploy process already holds the same cache lock.
+// when another npub process already holds the same cache lock.
 func AcquireLock(cacheDir string) (*Lock, error) {
 	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
 		return nil, fmt.Errorf("creating cache directory %s: %w", cacheDir, err)
@@ -34,7 +34,7 @@ func AcquireLock(cacheDir string) (*Lock, error) {
 	path := LockPath(cacheDir)
 	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o644)
 	if err != nil {
-		return nil, fmt.Errorf("opening deploy lock %s: %w", path, err)
+		return nil, fmt.Errorf("opening cache lock %s: %w", path, err)
 	}
 
 	if err := lockFile(file); err != nil {
@@ -42,7 +42,7 @@ func AcquireLock(cacheDir string) (*Lock, error) {
 		if errors.Is(err, errLockHeld) {
 			return nil, fmt.Errorf("another `npub` command is using this cache (lock at `%s`); rerun once it finishes", path)
 		}
-		return nil, fmt.Errorf("locking deploy cache %s: %w", path, err)
+		return nil, fmt.Errorf("locking npub cache %s: %w", path, err)
 	}
 
 	return &Lock{path: path, file: file}, nil
@@ -55,10 +55,10 @@ func (l *Lock) Release() error {
 	}
 	if err := unlockFile(l.file); err != nil {
 		_ = l.file.Close()
-		return fmt.Errorf("unlocking deploy cache %s: %w", l.path, err)
+		return fmt.Errorf("unlocking npub cache %s: %w", l.path, err)
 	}
 	if err := l.file.Close(); err != nil {
-		return fmt.Errorf("closing deploy lock %s: %w", l.path, err)
+		return fmt.Errorf("closing cache lock %s: %w", l.path, err)
 	}
 	l.file = nil
 	return nil


### PR DESCRIPTION
## Summary

- Add `npub clear` for removing only the managed `<cache_path>/build` output directory
- Write a `.npub-build` marker during builds and require it before clearing non-empty output
- Add dangerous-path checks and reuse the cache lock for managed builds/clear/deploy

## Checklist

- [x] Updated `CHANGELOG.md` under `Unreleased`, or change is internal-only

## References

- Closes #54
