### PR TITLE
Address clear command review followups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 
+- Rename the cache lock file from `.deploy.lock` to `.npub-cache.lock` and make `npub clear --dry-run` validate marker guardrails.
 - Remove the `npub build --out` override so builds always target the managed `<cache_path>/build` directory.
 - Adopt an Unreleased-first changelog and release-PR versioning workflow so multiple PRs can be bundled into one release ([#83]).
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Clear the managed build output:
 npub clear
 ```
 
-`npub clear` removes only the managed `<cache_path>/build` directory. It does not accept arbitrary paths. Non-empty build output must contain npub's `.npub-build` marker, which `npub build` writes as a deletion guardrail.
+`npub clear` removes only the managed `<cache_path>/build` directory. It does not accept arbitrary paths. Non-empty build output must contain npub's `.npub-build` marker, which `npub build` writes as a deletion guardrail. Use `--dry-run` to validate the target and marker without removing anything.
 
 ## Notes format
 

--- a/cmd/npub/main.go
+++ b/cmd/npub/main.go
@@ -190,7 +190,15 @@ npub's ownership marker.`,
 		}
 		dryRun, _ := cmd.Flags().GetBool("dry-run")
 		if dryRun {
-			_, err := fmt.Fprintf(cmd.OutOrStdout(), "would clear %s\n", buildDir)
+			canClear, err := checkClearableBuildDir(buildDir)
+			if err != nil {
+				return err
+			}
+			if !canClear {
+				_, err = fmt.Fprintf(cmd.OutOrStdout(), "%s does not exist\n", buildDir)
+				return err
+			}
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "would clear %s\n", buildDir)
 			return err
 		}
 
@@ -200,6 +208,9 @@ npub's ownership marker.`,
 		}
 		defer func() { _ = lock.Release() }()
 
+		if err := validateClearTarget(buildDir, cacheDir, cfg); err != nil {
+			return err
+		}
 		cleared, err := clearBuildDir(buildDir)
 		if err != nil {
 			return err
@@ -432,6 +443,17 @@ func loadConfigForClear(cmd *cobra.Command, cfgPath string) (config.Config, erro
 }
 
 func clearBuildDir(buildDir string) (bool, error) {
+	canClear, err := checkClearableBuildDir(buildDir)
+	if err != nil || !canClear {
+		return canClear, err
+	}
+	if err := os.RemoveAll(buildDir); err != nil {
+		return false, fmt.Errorf("clearing %s: %w", buildDir, err)
+	}
+	return true, nil
+}
+
+func checkClearableBuildDir(buildDir string) (bool, error) {
 	info, err := os.Stat(buildDir)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -453,9 +475,6 @@ func clearBuildDir(buildDir string) (bool, error) {
 			}
 			return false, fmt.Errorf("checking build marker: %w", err)
 		}
-	}
-	if err := os.RemoveAll(buildDir); err != nil {
-		return false, fmt.Errorf("clearing %s: %w", buildDir, err)
 	}
 	return true, nil
 }
@@ -485,20 +504,30 @@ func validateClearTarget(buildDir, cacheDir string, cfg config.Config) error {
 		return err
 	}
 
-	important := map[string]string{
-		"cache_path":  cacheDir,
-		"git dir":     deploy.GitDir(cacheDir),
-		"notes_path":  cfg.NotesPath,
-		"assets_path": cfg.AssetsPath,
-		"static_path": cfg.StaticPath,
+	important := []struct {
+		name string
+		path string
+	}{
+		{name: "cache_path", path: cacheDir},
+		{name: "deploy git directory", path: deploy.GitDir(cacheDir)},
+		{name: "notes_path", path: cfg.NotesPath},
+		{name: "assets_path", path: cfg.AssetsPath},
+		{name: "static_path", path: cfg.StaticPath},
 	}
 	if home, err := os.UserHomeDir(); err == nil {
-		important["home directory"] = home
+		important = append(important, struct {
+			name string
+			path string
+		}{name: "home directory", path: home})
 	}
 	if cwd, err := os.Getwd(); err == nil {
-		important["current working directory"] = cwd
+		important = append(important, struct {
+			name string
+			path string
+		}{name: "current working directory", path: cwd})
 	}
-	for name, path := range important {
+	for _, entry := range important {
+		name, path := entry.name, entry.path
 		if path == "" {
 			continue
 		}

--- a/cmd/npub/main_test.go
+++ b/cmd/npub/main_test.go
@@ -198,14 +198,9 @@ notes_path: "/tmp/notes"
 func TestClearCommandDryRunUsesManagedBuildDir(t *testing.T) {
 	dir := t.TempDir()
 	cacheDir := filepath.Join(dir, "cache")
-	cfgPath := filepath.Join(dir, config.DefaultConfigFile)
-	require.NoError(t, os.WriteFile(cfgPath, []byte(`
-notes_path: "/tmp/notes"
-site_root_url: "https://example.com"
-site_name: "Test Site"
-author_name: "Test Author"
-cache_path: "`+cacheDir+`"
-`), 0o644))
+	buildDir := deploy.BuildDir(cacheDir)
+	require.NoError(t, build.WriteBuildMarker(buildDir))
+	cfgPath := writeClearTestConfig(t, dir, cacheDir)
 
 	var buf bytes.Buffer
 	rootCmd.SetOut(&buf)
@@ -217,8 +212,44 @@ cache_path: "`+cacheDir+`"
 	})
 
 	require.NoError(t, rootCmd.Execute())
-	assert.Contains(t, buf.String(), "would clear "+deploy.BuildDir(cacheDir))
-	assert.NoDirExists(t, deploy.BuildDir(cacheDir))
+	assert.Contains(t, buf.String(), "would clear "+buildDir)
+	assert.DirExists(t, buildDir)
+}
+
+func TestClearCommandDryRunChecksMarker(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(dir, "cache")
+	buildDir := deploy.BuildDir(cacheDir)
+	require.NoError(t, os.MkdirAll(buildDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(buildDir, "index.html"), []byte("site"), 0o644))
+	cfgPath := writeClearTestConfig(t, dir, cacheDir)
+
+	var buf bytes.Buffer
+	rootCmd.SetOut(&buf)
+	rootCmd.SetErr(&buf)
+	rootCmd.SetArgs([]string{"clear", "--config", cfgPath, "--dry-run"})
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+		resetFlags(rootCmd)
+	})
+
+	err := rootCmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not marked as an npub build directory")
+	assert.FileExists(t, filepath.Join(buildDir, "index.html"))
+}
+
+func writeClearTestConfig(t *testing.T, dir, cacheDir string) string {
+	t.Helper()
+	cfgPath := filepath.Join(dir, config.DefaultConfigFile)
+	require.NoError(t, os.WriteFile(cfgPath, []byte(`
+notes_path: "/tmp/notes"
+site_root_url: "https://example.com"
+site_name: "Test Site"
+author_name: "Test Author"
+cache_path: "`+cacheDir+`"
+`), 0o644))
+	return cfgPath
 }
 
 func TestClearCommandRejectsPositionalPathAndBuildHasNoOutFlag(t *testing.T) {

--- a/internal/deploy/deploy.go
+++ b/internal/deploy/deploy.go
@@ -14,6 +14,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/dreikanter/npub/internal/build"
 )
 
 // CacheRoot returns the root directory used for deploy artifacts.
@@ -68,8 +70,6 @@ func RepoSlug(repoURL string) string {
 	}
 	return s
 }
-
-const buildMarkerName = ".npub-build"
 
 // Options controls Prepare, Commit, and Push.
 type Options struct {
@@ -152,7 +152,7 @@ func Prepare(repoURL, gitDir, buildDir string, opt Options) error {
 		}
 	}
 
-	if err := ensureGitExclude(gitDir, buildMarkerName); err != nil {
+	if err := ensureGitExclude(gitDir, build.BuildMarkerName); err != nil {
 		return err
 	}
 

--- a/internal/deploy/deploy_test.go
+++ b/internal/deploy/deploy_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/dreikanter/npub/internal/build"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -40,7 +41,7 @@ func TestBuildGitAndLockDir(t *testing.T) {
 	cache := "/tmp/whatever"
 	assert.Equal(t, "/tmp/whatever/build", BuildDir(cache))
 	assert.Equal(t, "/tmp/whatever/git", GitDir(cache))
-	assert.Equal(t, "/tmp/whatever/.deploy.lock", LockPath(cache))
+	assert.Equal(t, "/tmp/whatever/.npub-cache.lock", LockPath(cache))
 }
 
 func TestAcquireLockRejectsConcurrentUse(t *testing.T) {
@@ -64,12 +65,12 @@ func TestAcquireLockRejectsConcurrentUse(t *testing.T) {
 func TestEnsureGitExcludeAddsPatternOnce(t *testing.T) {
 	gitDir := t.TempDir()
 
-	require.NoError(t, ensureGitExclude(gitDir, buildMarkerName))
-	require.NoError(t, ensureGitExclude(gitDir, buildMarkerName))
+	require.NoError(t, ensureGitExclude(gitDir, build.BuildMarkerName))
+	require.NoError(t, ensureGitExclude(gitDir, build.BuildMarkerName))
 
 	data, err := os.ReadFile(filepath.Join(gitDir, "info", "exclude"))
 	require.NoError(t, err)
-	assert.Equal(t, ".npub-build\n", string(data))
+	assert.Equal(t, build.BuildMarkerName+"\n", string(data))
 }
 
 func TestPrepareRefusesEmptyBuildDir(t *testing.T) {

--- a/internal/deploy/lock.go
+++ b/internal/deploy/lock.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 )
 
-const cacheLockFile = ".deploy.lock"
+const cacheLockFile = ".npub-cache.lock"
 
 var errLockHeld = errors.New("cache lock already held")
 


### PR DESCRIPTION
## Summary

- Rename the shared cache lock file to `.npub-cache.lock`
- Make `npub clear --dry-run` validate the marker guardrail before reporting success
- Re-run clear target validation after acquiring the cache lock and make path checks deterministic
- Reuse the build marker constant from deploy git exclude handling

## Checklist

- [x] Updated `CHANGELOG.md` under `Unreleased`, or change is internal-only

## References

- Follow-up to #86
