### PR TITLE
Make builds atomic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Fixed
 
+- Make `npub build` atomic by rendering into a temporary directory before replacing `<cache_path>/build`, leaving the previous successful build intact if rendering fails.
 - Fail fast when another `npub deploy` is already using the same cache directory, avoiding concurrent git index mutations.
 
 [#86]: https://github.com/dreikanter/npub/pull/86

--- a/cmd/npub/main.go
+++ b/cmd/npub/main.go
@@ -93,7 +93,7 @@ operations happen in deploy.`,
 
 		log.Printf("building site from %s to %s", cfg.NotesPath, buildPath)
 		store := note.NewOSStore(cfg.NotesPath)
-		if err := build.Build(store, cfg, buildPath, npub.Assets); err != nil {
+		if err := build.AtomicBuild(store, cfg, buildPath, npub.Assets); err != nil {
 			return err
 		}
 		log.Println("build complete")

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -196,6 +196,84 @@ type Assets struct {
 	FaviconSVG []byte
 }
 
+// RemoveStaleTempBuildDirs removes temporary build directories left by failed
+// or interrupted atomic builds next to buildPath.
+func RemoveStaleTempBuildDirs(buildPath string) error {
+	parent := filepath.Dir(buildPath)
+	prefix := filepath.Base(buildPath) + ".tmp-"
+
+	entries, err := os.ReadDir(parent)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("reading build parent directory: %w", err)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() || !strings.HasPrefix(entry.Name(), prefix) {
+			continue
+		}
+		path := filepath.Join(parent, entry.Name())
+		if err := os.RemoveAll(path); err != nil {
+			return fmt.Errorf("removing stale temporary build directory %s: %w", path, err)
+		}
+	}
+	return nil
+}
+
+// AtomicBuild renders the site into a temporary directory next to buildPath,
+// then replaces buildPath only after rendering succeeds. If rendering fails,
+// the previous buildPath contents are left untouched.
+func AtomicBuild(store note.Store, cfg config.Config, buildPath string, assets Assets) error {
+	parent := filepath.Dir(buildPath)
+	prefix := filepath.Base(buildPath) + ".tmp-"
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return fmt.Errorf("creating build parent directory: %w", err)
+	}
+	if err := RemoveStaleTempBuildDirs(buildPath); err != nil {
+		return err
+	}
+
+	tmpPath, err := os.MkdirTemp(parent, prefix)
+	if err != nil {
+		return fmt.Errorf("creating temporary build directory: %w", err)
+	}
+	cleanupTmp := true
+	defer func() {
+		if cleanupTmp {
+			_ = os.RemoveAll(tmpPath)
+		}
+	}()
+
+	if err := Build(store, cfg, tmpPath, assets); err != nil {
+		return err
+	}
+
+	oldPath := filepath.Join(parent, filepath.Base(buildPath)+".old-"+strings.TrimPrefix(filepath.Base(tmpPath), prefix))
+	movedOld := false
+	if err := os.Rename(buildPath, oldPath); err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("moving previous build directory aside: %w", err)
+		}
+	} else {
+		movedOld = true
+	}
+
+	if err := os.Rename(tmpPath, buildPath); err != nil {
+		if movedOld {
+			_ = os.Rename(oldPath, buildPath)
+		}
+		return fmt.Errorf("replacing build directory: %w", err)
+	}
+	cleanupTmp = false
+	if movedOld {
+		if err := os.RemoveAll(oldPath); err != nil {
+			return fmt.Errorf("removing previous build directory: %w", err)
+		}
+	}
+	return nil
+}
+
 // Build generates the static site from notes into buildPath. buildPath is
 // the directory the rendered files are written to; cfg supplies everything
 // else (notes location, site metadata, etc).

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -2,9 +2,11 @@ package build
 
 import (
 	"bytes"
+	"errors"
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -82,6 +84,66 @@ func TestCleanBuildDirRejectsHome(t *testing.T) {
 	require.Error(t, cleanBuildDir(home))
 }
 
+func TestAtomicBuildLeavesPreviousBuildOnFailure(t *testing.T) {
+	cacheDir := t.TempDir()
+	buildDir := filepath.Join(cacheDir, "build")
+	assetsDir := t.TempDir()
+
+	require.NoError(t, os.MkdirAll(buildDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(buildDir, "index.html"), []byte("previous"), 0o644))
+	require.NoError(t, WriteBuildMarker(buildDir))
+
+	cfg := testConfig(t, buildDir, assetsDir)
+	err := AtomicBuild(failingStore{err: errors.New("boom")}, cfg, buildDir, Assets{
+		Templates:  os.DirFS("../../"),
+		StyleCSS:   []byte("/* test */"),
+		FaviconSVG: []byte("<svg></svg>"),
+	})
+	require.Error(t, err)
+
+	data, readErr := os.ReadFile(filepath.Join(buildDir, "index.html"))
+	require.NoError(t, readErr)
+	assert.Equal(t, "previous", string(data))
+	assert.FileExists(t, filepath.Join(buildDir, BuildMarkerName))
+	assert.Empty(t, tempBuildDirNames(t, cacheDir))
+}
+
+func TestAtomicBuildReplacesBuildOnSuccessAndRemovesStaleTemps(t *testing.T) {
+	cacheDir := t.TempDir()
+	buildDir := filepath.Join(cacheDir, "build")
+	assetsDir := t.TempDir()
+	staleDir := filepath.Join(cacheDir, "build.tmp-stale")
+
+	require.NoError(t, os.MkdirAll(buildDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(buildDir, "old.html"), []byte("old"), 0o644))
+	require.NoError(t, os.MkdirAll(staleDir, 0o755))
+
+	store := note.NewMemStore()
+	_, err := store.Put(note.Entry{
+		ID: 3961,
+		Meta: note.Meta{
+			Title:     "Atomic Note",
+			Slug:      "atomic-note",
+			Public:    true,
+			CreatedAt: time.Date(2023, 1, 30, 0, 0, 0, 0, time.UTC),
+		},
+		Body: "New build.\n",
+	})
+	require.NoError(t, err)
+
+	cfg := testConfig(t, buildDir, assetsDir)
+	require.NoError(t, AtomicBuild(store, cfg, buildDir, Assets{
+		Templates:  os.DirFS("../../"),
+		StyleCSS:   []byte("/* test */"),
+		FaviconSVG: []byte("<svg></svg>"),
+	}))
+
+	assert.NoFileExists(t, filepath.Join(buildDir, "old.html"))
+	assert.FileExists(t, filepath.Join(buildDir, "atomic-note", "index.html"))
+	assert.FileExists(t, filepath.Join(buildDir, BuildMarkerName))
+	assert.Empty(t, tempBuildDirNames(t, cacheDir))
+}
+
 func testConfig(t *testing.T, _, assetsPath string) config.Config {
 	t.Helper()
 	return config.Config{
@@ -90,6 +152,28 @@ func testConfig(t *testing.T, _, assetsPath string) config.Config {
 		SiteName:    "Test Site",
 		AuthorName:  "Test Author",
 	}
+}
+
+type failingStore struct {
+	note.Store
+	err error
+}
+
+func (s failingStore) All(opts ...note.QueryOpt) ([]note.Entry, error) {
+	return nil, s.err
+}
+
+func tempBuildDirNames(t *testing.T, cacheDir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(cacheDir)
+	require.NoError(t, err)
+	var names []string
+	for _, entry := range entries {
+		if entry.IsDir() && strings.HasPrefix(entry.Name(), "build.tmp-") {
+			names = append(names, entry.Name())
+		}
+	}
+	return names
 }
 
 func TestBuildPublicNote(t *testing.T) {


### PR DESCRIPTION
## Summary

- Render managed builds into a same-cache temporary directory before swapping them into `<cache_path>/build`
- Remove stale `build.tmp-*` directories while holding the existing build cache lock
- Keep the previous successful build intact if rendering fails

## Checklist

- [x] Updated `CHANGELOG.md` under `Unreleased`, or change is internal-only

## References

- Closes #85
