### PR TITLE
Add generator meta tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Add a `generator` meta tag to rendered HTML identifying the npub version used for the build.
 - Add `npub clear` to remove only the managed `<cache_path>/build` output directory, guarded by an npub marker file and dangerous-path checks ([#86]).
 
 ### Changed

--- a/cmd/npub/main.go
+++ b/cmd/npub/main.go
@@ -93,7 +93,9 @@ operations happen in deploy.`,
 
 		log.Printf("building site from %s to %s", cfg.NotesPath, buildPath)
 		store := note.NewOSStore(cfg.NotesPath)
-		if err := build.AtomicBuild(store, cfg, buildPath, npub.Assets); err != nil {
+		assets := npub.Assets
+		assets.Generator = "npub " + Version
+		if err := build.AtomicBuild(store, cfg, buildPath, assets); err != nil {
 			return err
 		}
 		log.Println("build complete")

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -43,6 +43,7 @@ type configData struct {
 	FeedPath       string
 	LicenseName    string
 	LicenseURL     string
+	Generator      string
 	StyleCSS       template.CSS
 	HighlightCSS   template.CSS
 	FaviconDataURI template.URL
@@ -194,6 +195,7 @@ type Assets struct {
 	Templates  fs.FS
 	StyleCSS   []byte
 	FaviconSVG []byte
+	Generator  string
 }
 
 // RemoveStaleTempBuildDirs removes temporary build directories left by failed
@@ -340,6 +342,10 @@ func Build(store note.Store, cfg config.Config, buildPath string, assets Assets)
 		return fmt.Errorf("parsing feed template: %w", err)
 	}
 
+	generator := assets.Generator
+	if generator == "" {
+		generator = "npub"
+	}
 	cfgData := configData{
 		SiteName:       cfg.SiteName,
 		SiteDomain:     cfg.SiteDomain(),
@@ -350,6 +356,7 @@ func Build(store note.Store, cfg config.Config, buildPath string, assets Assets)
 		FeedPath:       cfg.FeedPath(),
 		LicenseName:    cfg.LicenseName,
 		LicenseURL:     cfg.LicenseURL,
+		Generator:      generator,
 		StyleCSS:       template.CSS(assets.StyleCSS),
 		HighlightCSS:   template.CSS(render.HighlightCSS()),
 		FaviconDataURI: faviconDataURI(assets.FaviconSVG),

--- a/internal/build/build_test.go
+++ b/internal/build/build_test.go
@@ -199,6 +199,7 @@ func TestBuildPublicNote(t *testing.T) {
 		Templates:  os.DirFS("../../"),
 		StyleCSS:   []byte("/* test */"),
 		FaviconSVG: []byte("<svg></svg>"),
+		Generator:  "npub test-version",
 	}
 	require.NoError(t, Build(store, cfg, buildDir, assets))
 
@@ -236,6 +237,7 @@ func TestBuildPublicNote(t *testing.T) {
 	indexData, err := os.ReadFile(filepath.Join(buildDir, "index.html"))
 	require.NoError(t, err)
 	assert.Contains(t, string(indexData), "/* test */")
+	assert.Contains(t, string(indexData), `<meta name="generator" content="npub test-version" />`)
 	assert.Contains(t, string(indexData), `href="data:image/svg&#43;xml;base64,PHN2Zz48L3N2Zz4="`)
 	assert.NotContains(t, string(indexData), `href="/style.css"`)
 }

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <meta name="author" content="{{.Config.AuthorName}}">
   <meta name="description" content="{{.Page.MetaDescription}}" />
+  <meta name="generator" content="{{.Config.Generator}}" />
   <title>{{if .Page.Title}}{{.Page.Title}} - {{end}}{{.Config.SiteName}}</title>
   {{if .Page.CanonicalPath}}
     <link rel="canonical" href="{{.Config.SiteRootURL}}/{{.Page.CanonicalPath}}">


### PR DESCRIPTION
## Summary

- Add a generator meta tag to rendered HTML with the current npub version
- Pass the CLI version into build rendering assets
- Cover the generator meta tag in build tests

## Checklist

- [x] Updated `CHANGELOG.md` under `Unreleased`, or change is internal-only
