### PR TITLE
Drop redundant 'version' word from --version output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- `npub --version` no longer prints a redundant `version v...`; the output is now `npub vX.Y.Z`.
+
 ### Changed
 
 - Simplify the README's Configuration section to point at the sample file, `npub init`, and `--config`; expand the assets cache explanation; add subheaders to Usage and a frontmatter example to Notes format.

--- a/cmd/npub/main.go
+++ b/cmd/npub/main.go
@@ -591,6 +591,7 @@ func init() {
 		}
 	}
 	rootCmd.Version = Version
+	rootCmd.SetVersionTemplate("{{.Name}} {{.Version}}\n")
 
 	rootCmd.PersistentFlags().String("config", "", "config file path (default: npub.yml)")
 


### PR DESCRIPTION
## Summary

- `npub --version` previously printed `npub version v...`, with a redundant `version v` because git tags use the `vX.Y.Z` form and Cobra's default version template adds its own `version` word.
- Override Cobra's version template to `{{.Name}} {{.Version}}`, so output is now `npub v...`.
- Keeps `Version` matching the canonical git tag / Go module version (also returned by `debug.ReadBuildInfo`), so the displayed string is consistent across local builds and `go install ...@vX.Y.Z` builds.

## Checklist

- [x] Updated `CHANGELOG.md` under `Unreleased`, or change is internal-only